### PR TITLE
Doc/install Adding uvx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ gNMIBuddy integrates with LLMs through the [Model Context Protocol (MCP)](https:
 | **Claude Desktop** | [📋 Copy config](examples/mcp/claude-desktop-uvx.json) | See Claude Docs    |
 
 > [!TIP]
-> Copy the configuration file contents and update `path/to/your_inventory.json` with your actual inventory file path.
+> Copy the configuration file contents and update the paths.
 
 ### 🧪 Testing Your Setup
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy --help
 uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy --inventory your_inventory.json device list
 ```
 
-> ![TIP] Don't want to always type the inventory? use the `NETWORK_INVENTORY` env var.
+> ![TIP]
+> Don't want to always type the inventory? use the `NETWORK_INVENTORY` env var.
 
 ### Install as a persistent tool
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy --help
 uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy --inventory your_inventory.json device list
 ```
 
-> ![TIP]
+> [!TIP]
 > Don't want to always type the inventory? use the `NETWORK_INVENTORY` env var.
 
 ### Install as a persistent tool

--- a/README.md
+++ b/README.md
@@ -156,134 +156,63 @@ Run 'gnmibuddy.py COMMAND --help' for more information on a command.
 
 ## 🤖 LLM Integration (MCP)
 
-<details>
-<summary><strong>🚀 Easy Setup with uvx (No Repository Cloning Required)</strong></summary>
+gNMIBuddy integrates with LLMs through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction), providing network telemetry tools for AI agents.
 
-### VSCode Setup (uvx)
+### 🚀 Quick Start (Recommended)
 
-Create `.vscode/mcp.json` in your project:
+**No installation required** - runs directly from GitHub using `uvx`:
 
-```json
-{
-  "servers": {
-    "gNMIBuddy": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/jillesca/gNMIBuddy.git",
-        "gnmibuddy-mcp"
-      ],
-      "env": {
-        "NETWORK_INVENTORY": "${workspaceFolder}/<your_inventory_file>.json"
-      }
-    }
-  }
-}
-```
+| **MCP Client**     | **Configuration**                                      | **Location**       |
+| ------------------ | ------------------------------------------------------ | ------------------ |
+| **VSCode**         | [📋 Copy config](examples/mcp/vscode-uvx.json)         | `.vscode/mcp.json` |
+| **Cursor**         | [📋 Copy config](examples/mcp/cursor-uvx.json)         | `.cursor/mcp.json` |
+| **Claude Desktop** | [📋 Copy config](examples/mcp/claude-desktop-uvx.json) | See Claude Docs    |
 
-### Claude Desktop Setup (uvx)
+> [!TIP]
+> Copy the configuration file contents and update `path/to/your_inventory.json` with your actual inventory file path.
 
-Add to Claude's configuration (Settings > Developer > Edit config):
-
-```json
-{
-  "mcpServers": {
-    "gNMIBuddy": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/jillesca/gNMIBuddy.git",
-        "gnmibuddy-mcp"
-      ],
-      "env": {
-        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
-      }
-    }
-  }
-}
-```
-
-### Testing MCP (uvx)
-
-Use the MCP inspector for testing:
+### 🧪 Testing Your Setup
 
 ```bash
-# Replace `your_inventory.json` with your actual inventory file
+# Test the MCP integration
 NETWORK_INVENTORY=your_inventory.json \
 npx @modelcontextprotocol/inspector \
 uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy-mcp
 ```
 
+<details>
+<summary><strong>🔧 Development Setup</strong></summary>
+
+If you're developing or want full control over the installation:
+
+1. **Clone the repository**:
+
+   ```bash
+   git clone https://github.com/jillesca/gNMIBuddy.git
+   cd gNMIBuddy
+   ```
+
+2. **Choose your configuration**:
+
+| **MCP Client**     | **Configuration**                                      |
+| ------------------ | ------------------------------------------------------ |
+| **VSCode**         | [📋 Copy config](examples/mcp/vscode-dev.json)         |
+| **Cursor**         | [📋 Copy config](examples/mcp/cursor-dev.json)         |
+| **Claude Desktop** | [📋 Copy config](examples/mcp/claude-desktop-dev.json) |
+
+3. **Test the development setup**:
+
+   ```bash
+   NETWORK_INVENTORY=your_inventory.json \
+   npx @modelcontextprotocol/inspector \
+   uv run --with "mcp[cli],pygnmi,networkx,pyyaml" \
+   mcp run mcp_server.py
+   ```
+
 </details>
 
-### Traditional Setup (Requires Repository Cloning)
-
-If you prefer to clone the repository and have more control over the setup:
-
-#### VSCode Setup
-
-Create `.vscode/mcp.json` in your project:
-
-```json
-{
-  "servers": {
-    "gNMIBuddy": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--with",
-        "mcp[cli],pygnmi,networkx,pyyaml",
-        "mcp",
-        "run",
-        "${workspaceFolder}/mcp_server.py"
-      ],
-      "env": {
-        "NETWORK_INVENTORY": "${workspaceFolder}/<your_inventory_file>.json"
-      }
-    }
-  }
-}
-```
-
-#### Claude Desktop Setup
-
-Add to Claude's configuration (Settings > Developer > Edit config):
-
-```json
-{
-  "mcpServers": {
-    "gNMIBuddy": {
-      "command": "uv",
-      "args": [
-        "run",
-        "--with",
-        "mcp[cli],pygnmi,networkx,pyyaml",
-        "mcp",
-        "run",
-        "/absolute/path/to/mcp_server.py"
-      ],
-      "env": {
-        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
-      }
-    }
-  }
-}
-```
-
-#### Testing MCP
-
-Use the MCP inspector for testing.
-
-```bash
-# Replace `xrd_sandbox.json` with your actual inventory file.
-NETWORK_INVENTORY=xrd_sandbox.json \
-npx @modelcontextprotocol/inspector \
-uv run --with "mcp[cli],pygnmi,networkx,pyyaml" \
-mcp run mcp_server.py
-```
-
 > [!IMPORTANT]
-> For MCP set the `NETWORK_INVENTORY` environment variable to your inventory file or you'll get errors.
+> Set the `NETWORK_INVENTORY` environment variable to your inventory file.
 
 ## 🧪 Testing with DevNet Sandbox
 
@@ -301,7 +230,6 @@ Then test with the provided `xrd_sandbox.json` inventory file.
 ### Testing with AI Agents
 
 Want to see how this MCP tool integrates with actual AI agents? Check out [sp_oncall](https://github.com/jillesca/sp_oncall) - a graph of agents that use gNMIBuddy to demonstrate real-world network operations scenarios.
-.
 
 ## 📋 Response Format
 

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -21,7 +21,9 @@ This directory contains ready-to-use configuration files for integrating gNMIBud
 **Cursor**: Copy contents to `.cursor/mcp.json` in your project  
 **Claude Desktop**: Add contents to your Claude configuration file
 
-### 3. Update Inventory Path
+### 3. Update Paths
+
+Replace `path/to/mcp_server.py` with the path to the `mcp_server` file.
 
 Replace `path/to/your_inventory.json` with the actual path to your network inventory file.
 

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,67 @@
+# MCP Configuration Examples
+
+This directory contains ready-to-use configuration files for integrating gNMIBuddy with various MCP clients.
+
+## File Naming Convention
+
+- `{client}-uvx.json`: No installation required, runs directly from GitHub
+- `{client}-dev.json`: For development setup with cloned repository
+
+## Setup Instructions
+
+### 1. Choose Your Approach
+
+**Quick Start (Recommended)**: Use the `uvx` configurations - no need to clone the repository.
+
+**Development**: Use the `dev` configurations if you plan to modify gNMIBuddy or want full control.
+
+### 2. Copy Configuration
+
+**VSCode**: Copy contents to `.vscode/mcp.json` in your project
+**Cursor**: Copy contents to `.cursor/mcp.json` in your project  
+**Claude Desktop**: Add contents to your Claude configuration file
+
+### 3. Update Inventory Path
+
+Replace `path/to/your_inventory.json` with the actual path to your network inventory file.
+
+All configurations **must** use the `NETWORK_INVENTORY` environment variable to specifying the inventory path in the configuration file.
+
+## Configuration Locations
+
+### VSCode
+
+```
+your-project/
+├── .vscode/
+│   └── mcp.json
+```
+
+### Cursor
+
+```
+your-project/
+├── .cursor/
+│   └── mcp.json
+```
+
+### Claude Desktop
+
+See Claude Docs.
+
+## Testing
+
+Use the MCP inspector to test your configuration:
+
+```bash
+# For uvx setup
+NETWORK_INVENTORY=your_inventory.json \
+npx @modelcontextprotocol/inspector \
+uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy-mcp
+
+# For development setup
+NETWORK_INVENTORY=your_inventory.json \
+npx @modelcontextprotocol/inspector \
+uv run --with "mcp[cli],pygnmi,networkx,pyyaml" \
+mcp run mcp_server.py
+```

--- a/examples/mcp/claude-desktop-dev.json
+++ b/examples/mcp/claude-desktop-dev.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "gNMIBuddy": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp[cli],pygnmi,networkx,pyyaml",
+        "mcp",
+        "run",
+        "/absolute/path/to/mcp_server.py"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
+      }
+    }
+  }
+}

--- a/examples/mcp/claude-desktop-dev.json
+++ b/examples/mcp/claude-desktop-dev.json
@@ -8,10 +8,10 @@
         "mcp[cli],pygnmi,networkx,pyyaml",
         "mcp",
         "run",
-        "/absolute/path/to/mcp_server.py"
+        "path/to/mcp_server.py"
       ],
       "env": {
-        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
       }
     }
   }

--- a/examples/mcp/claude-desktop-uvx.json
+++ b/examples/mcp/claude-desktop-uvx.json
@@ -8,7 +8,7 @@
         "gnmibuddy-mcp"
       ],
       "env": {
-        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
       }
     }
   }

--- a/examples/mcp/claude-desktop-uvx.json
+++ b/examples/mcp/claude-desktop-uvx.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "gNMIBuddy": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/jillesca/gNMIBuddy.git",
+        "gnmibuddy-mcp"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "/absolute/path/to/your_inventory.json"
+      }
+    }
+  }
+}

--- a/examples/mcp/cursor-dev.json
+++ b/examples/mcp/cursor-dev.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "gNMIBuddy": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp[cli],pygnmi,networkx,pyyaml",
+        "mcp",
+        "run",
+        "${workspaceFolder}/mcp_server.py"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
+      }
+    }
+  }
+}

--- a/examples/mcp/cursor-dev.json
+++ b/examples/mcp/cursor-dev.json
@@ -8,7 +8,7 @@
         "mcp[cli],pygnmi,networkx,pyyaml",
         "mcp",
         "run",
-        "${workspaceFolder}/mcp_server.py"
+        "path/to/mcp_server.py"
       ],
       "env": {
         "NETWORK_INVENTORY": "path/to/your_inventory.json"

--- a/examples/mcp/cursor-uvx.json
+++ b/examples/mcp/cursor-uvx.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "gNMIBuddy": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/jillesca/gNMIBuddy.git",
+        "gnmibuddy-mcp"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
+      }
+    }
+  }
+}

--- a/examples/mcp/vscode-dev.json
+++ b/examples/mcp/vscode-dev.json
@@ -1,0 +1,18 @@
+{
+  "servers": {
+    "gNMIBuddy": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "mcp[cli],pygnmi,networkx,pyyaml",
+        "mcp",
+        "run",
+        "${workspaceFolder}/mcp_server.py"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
+      }
+    }
+  }
+}

--- a/examples/mcp/vscode-dev.json
+++ b/examples/mcp/vscode-dev.json
@@ -8,7 +8,7 @@
         "mcp[cli],pygnmi,networkx,pyyaml",
         "mcp",
         "run",
-        "${workspaceFolder}/mcp_server.py"
+        "path/to/mcp_server.py"
       ],
       "env": {
         "NETWORK_INVENTORY": "path/to/your_inventory.json"

--- a/examples/mcp/vscode-uvx.json
+++ b/examples/mcp/vscode-uvx.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "gNMIBuddy": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/jillesca/gNMIBuddy.git",
+        "gnmibuddy-mcp"
+      ],
+      "env": {
+        "NETWORK_INVENTORY": "path/to/your_inventory.json"
+      }
+    }
+  }
+}


### PR DESCRIPTION
`uvx` is great to run a disposable command. Users don't need to clone manually the repo. Faster testing.