### PR TITLE
Device capabilities + preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Devices **must** support gNMI and OpenConfig models listed below:
 **OpenConfig Models dependencies**
 
 - `openconfig-system >= 0.17.1`
-- `openconfig-interfaces >= 4.0.0`
+- `openconfig-interfaces >= 3.0.0`
 - `openconfig-network-instance >= 1.3.0`
 
 **Tested on:**

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ gNMIBuddy identifies devices by hostname and looks up their corresponding IP add
 
 Provide device inventory via `--inventory PATH` or set `NETWORK_INVENTORY` env var.
 
+### Device Capabilities
+
+Fetch the device's gNMI capabilities (supported models, encodings, gNMI version):
+
+- Single device:
+  - uv run gnmibuddy.py --inventory path/to/devices.json device capabilities --device R1
+- All devices:
+  - uv run gnmibuddy.py --inventory path/to/devices.json device capabilities --all-devices
+
+Output formats:
+
+- JSON (default): add --output json
+- YAML: add --output yaml
+
 > [!TIP]
 > Store environment variables in a `.env` file.
 

--- a/ao_sandbox.json
+++ b/ao_sandbox.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ip_address": "131.226.217.150",
+    "nos": "iosxr",
+    "port": 57777,
+    "username": "admin",
+    "password": "C1sco12345",
+    "name": "xrd-1"
+  }
+]

--- a/docs/agent-prompts/issue-14-implementation-prompts.md
+++ b/docs/agent-prompts/issue-14-implementation-prompts.md
@@ -143,7 +143,7 @@ Prompt
   - infer_requirements(paths: list[str]) -> list[ModelRequirement]
 - Recognize the three top-level OpenConfig modules only:
   - openconfig-system → ModelRequirement(name="openconfig-system", minimum_version="0.17.1") when path starts with that module prefix.
-  - openconfig-interfaces → … minimum_version="4.0.0".
+  - openconfig-interfaces → … minimum_version="3.0.0".
   - openconfig-network-instance → … minimum_version="1.3.0".
 - Handle patterns like "openconfig-system:/system" and "openconfig-system:system".
 - Return unique requirements (no duplicates).

--- a/docs/agent-prompts/issue-14-implementation-prompts.md
+++ b/docs/agent-prompts/issue-14-implementation-prompts.md
@@ -1,0 +1,327 @@
+# Agent Prompts: Issue #14 — Review if device supports models required
+
+Use these prompts to guide LLM agents through a phased implementation of Issue #14. Each agent must:
+
+- First, read the issue thread, especially the comment titled: “Implementation plan for ‘Review if device supports models required’ (Authored by GitHub Copilot)”.
+- Also review the implementation plan on issue #14 for alignment.
+- Work only on their assigned phase. No scope creep. If you identify improvements, add them as notes on the issue instead of implementing them.
+- Do not use dictionaries to encapsulate related data and behavior. Use classes/dataclasses with methods for encapsulation and accessors.
+- After finishing, add a short summary comment to issue #14 stating what you implemented and any relevant notes (keep it concise; do not restate the plan).
+- When testing CLI, run with “uv run gnmibuddy.py …” and capture logs to a file for full output. For tests, run “pytest” via CLI.
+
+Global engineering guardrails
+
+- DRY, KISS, YAGNI, SOLID, modularity, readability (Zen of Python, Fowler refactoring).
+- Prefer small files with single responsibility. Use directory hierarchy as proposed in the plan.
+- Do not change public behavior beyond what the plan requires.
+- Follow output flag conventions used by current CLI commands.
+
+How to post your completion summary comment
+
+- Keep it short. Example:
+  - “Phase X complete: Implemented <module> with classes <A, B>. Added unit tests. CLI unaffected in this phase. Notes: <optional>.”
+
+---
+
+## Phase 0 — Context loading (read-only)
+
+Prompt
+
+- Read Issue #14 fully, focusing on the “Implementation plan … (Authored by GitHub Copilot)” comment.
+- Read Issue #14 implementation plan.
+- Skim the repo code paths mentioned in the plan to understand integration points (src/gnmi/client.py, src/gnmi/parameters.py, src/cmd/commands, collectors).
+- Do not modify code in this phase.
+- Post a brief comment on Issue #14 acknowledging context is understood and list any ambiguities found.
+
+Verification
+
+- None (read-only). Post the short comment.
+
+---
+
+## Phase 1 — Capabilities domain models (objects only)
+
+Scope
+
+- Create: src/gnmi/capabilities/models.py
+
+Prompt
+
+- Implement classes (no dicts-as-objects):
+  - ModelIdentifier: name (str), version (str|None), organization (str|None). Methods: normalized_version(), matches(name: str) -> bool.
+  - ModelRequirement: name (str), minimum_version (str|None). Methods: requires_version() -> bool.
+  - DeviceCapabilities: models (list[ModelIdentifier]), encodings (list[str]), gnmi_version (str|None). Methods:
+    - has_model(req: ModelRequirement, version_cmp: Callable) -> tuple[bool, bool] where returns (present, older_than_min).
+    - supports_encoding(encoding: str, normalize: Callable) -> bool.
+- Do not add external side effects. Keep types explicit and readable. Provide **repr**/**str** for developer clarity.
+- Do not import pygnmi here. This is pure data/domain.
+
+Constraints
+
+- No dictionaries to encapsulate behavior; use classes and methods.
+
+Verification
+
+- Add minimal unit tests in tests/gnmi/capabilities/test_models.py for the objects’ basic behavior (constructors and method returns).
+
+---
+
+## Phase 2 — Version normalization and comparison
+
+Scope
+
+- Create: src/gnmi/capabilities/version.py
+
+Prompt
+
+- Implement NormalizedVersion class:
+  - Accept common formats: semantic versions (e.g., 1.2.3), date-like (YYYY-MM-DD), or vendor strings.
+  - Provide comparison operations (**, **lt**,**eq\_\_, etc.).
+  - Provide from_string(s: str) -> NormalizedVersion and safe_compare(a: str|None, b: str|None) -> Optional[int].
+  - Comparison rules: semver > date-like > raw lexicographic fallback; unknown returns None.
+- Keep code small, readable, with docstrings and clear failure modes.
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_version.py for parsing and comparisons.
+
+---
+
+## Phase 3 — In-memory repository
+
+Scope
+
+- Create: src/gnmi/capabilities/repository.py
+
+Prompt
+
+- Implement DeviceCapabilitiesRepository class with an in-memory cache keyed by a stable device key (e.g., f"{nos}:{ip}:{port}"). Methods:
+  - make_key(device) -> str
+  - get(device) -> DeviceCapabilities|None
+  - set(device, caps: DeviceCapabilities) -> None
+  - has(device) -> bool
+  - clear() -> None
+- No persistence beyond process lifetime.
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_repository.py for keying, get/set/has/clear.
+
+---
+
+## Phase 4 — Capability service (fetch via Capabilities RPC)
+
+Scope
+
+- Create: src/gnmi/capabilities/service.py
+
+Prompt
+
+- Implement CapabilityService class with:
+  - **init**(repo: DeviceCapabilitiesRepository)
+  - get_or_fetch(device) -> DeviceCapabilities
+  - \_fetch(device) -> DeviceCapabilities: build connection params using existing GnmiConnectionManager; open a pygnmi gNMIclient connection; call capabilities; normalize into DeviceCapabilities and ModelIdentifier objects.
+- Map encodings from device to canonical forms (JSON_IETF → json_ietf, JSON → json, ASCII → ascii). Keep normalizer internal.
+- Store result in repository; return cached on subsequent calls.
+- Handle exceptions using existing error handling patterns (do not raise; let integrators convert errors if needed).
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_service.py using mocks/stubs for gNMIclient to validate normalization and caching.
+
+---
+
+## Phase 5 — Request inspector (infer required models from paths)
+
+Scope
+
+- Create: src/gnmi/capabilities/inspector.py
+
+Prompt
+
+- Implement RequestInspector class with:
+  - infer_requirements(paths: list[str]) -> list[ModelRequirement]
+- Recognize the three top-level OpenConfig modules only:
+  - openconfig-system → ModelRequirement(name="openconfig-system", minimum_version="0.17.1") when path starts with that module prefix.
+  - openconfig-interfaces → … minimum_version="4.0.0".
+  - openconfig-network-instance → … minimum_version="1.3.0".
+- Handle patterns like "openconfig-system:/system" and "openconfig-system:system".
+- Return unique requirements (no duplicates).
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_inspector.py for typical and edge path variants.
+
+---
+
+## Phase 6 — Encoding policy
+
+Scope
+
+- Create: src/gnmi/capabilities/encoding.py
+
+Prompt
+
+- Implement EncodingPolicy class:
+  - normalize(encoding: str|None) -> str|None (canonicalize to json_ietf/json/ascii; case-insensitive).
+  - choose_supported(requested: str|None, supported: list[str]) -> tuple[str|None, bool]
+    - If requested supported: return (requested, False)
+    - Else attempt fallback order: json_ietf → json → ascii where present in supported; return (fallback, True) or (None, False) if none.
+- No bytes fallback.
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_encoding.py for normalization and fallback selection.
+
+---
+
+## Phase 7 — Capability checker (orchestration)
+
+Scope
+
+- Create: src/gnmi/capabilities/checker.py and src/gnmi/capabilities/errors.py
+
+Prompt
+
+- Implement in errors.py simple constants or an Enum for error types: MODEL_NOT_SUPPORTED and ENCODING_NOT_SUPPORTED.
+- Implement CapabilityCheckResult class (in checker.py) with fields: success (bool), warnings (list[str]), selected_encoding (str|None), error_type (str|None), error_message (str|None). Provide simple helpers is_failure().
+- Implement CapabilityChecker class with:
+  - **init**(service: CapabilityService, version_cmp: Callable, encoding_policy: EncodingPolicy)
+  - check(device, paths: list[str], requested_encoding: str|None) -> CapabilityCheckResult
+    - Use RequestInspector to get requirements from paths.
+    - Use service.get_or_fetch(device) to obtain DeviceCapabilities.
+    - Validate encoding with EncodingPolicy; set selected_encoding; on none, return ENCODING_NOT_SUPPORTED failure.
+    - For each requirement: use DeviceCapabilities.has_model(req, version_cmp).
+      - If not present: return MODEL_NOT_SUPPORTED failure with a clear message stating missing model and required version.
+      - If older_than_min: add a warning and continue.
+    - On success: return success with warnings (if any) and selected_encoding.
+
+Verification
+
+- Add tests in tests/gnmi/capabilities/test_checker.py for missing model, older model (warning), unsupported encoding, fallback encoding, and all-good paths.
+
+---
+
+## Phase 8 — GnmiRequest: infer_models() method
+
+Scope
+
+- Modify: src/gnmi/parameters.py
+
+Prompt
+
+- Add an instance method infer_models(self) -> list[ModelRequirement] that calls RequestInspector.infer_requirements(self.path). Import only the type(s) needed and keep it thin.
+- Do not change existing fields or constructor.
+
+Verification
+
+- Add tests in tests/gnmi/test_parameters_infer_models.py that create a GnmiRequest with paths and assert inferred requirements.
+
+---
+
+## Phase 9 — gNMI client preflight integration
+
+Scope
+
+- Modify: src/gnmi/client.py
+
+Prompt
+
+- In GnmiRequestExecutor.execute_request, before opening gNMIclient:
+  - Instantiate CapabilityService (with a shared repository), EncodingPolicy, and CapabilityChecker (wire version comparator from NormalizedVersion and encoding normalizer).
+  - Call request.infer_models() to get requirements; pass request.path and request.encoding into the checker.
+  - If result is failure: return an ErrorResponse with type from errors.py and a clear message (do not call get()).
+  - If result selected a fallback encoding: update a local copy of request with the selected encoding for this single call; do not mutate global state.
+  - If warnings exist (older versions), log them at warning level and continue.
+- Keep retry and error handling intact; do not alter public behavior when capabilities are satisfied.
+
+Verification
+
+- Add tests in tests/gnmi/test_client_capabilities_integration.py using mocks to simulate capabilities and assert early return on failures and fallback mutation only for the call.
+- Manual smoke: run a simple CLI call and capture logs.
+
+---
+
+## Phase 10 — CLI command: device capabilities
+
+Scope
+
+- Create: src/cmd/commands/device/capabilities.py
+
+Prompt
+
+- Implement a new command under the device group (follow the structure and decorators used by device/info.py):
+  - Name: capabilities
+  - Behavior: fetch capabilities via CapabilityService, print:
+    - Supported OpenConfig models (name and version)
+    - Supported encoding formats (normalized names)
+    - Validation result against the three minimums (meets/older/missing)
+  - Follow existing output flag conventions of the CLI (respect --output json, etc.). Keep default formatting consistent with other device commands.
+  - Reuse shared formatting utilities if available; otherwise produce clean, minimal output.
+
+Verification
+
+- Manual: run
+
+  ```zsh
+  uv run gnmibuddy.py device capabilities --device <NAME> --output json > /tmp/caps.json
+  ```
+
+  Inspect the JSON and logs to confirm supported encodings and model checks are present.
+
+---
+
+## Phase 11 — Test suite and quality gates
+
+Scope
+
+- Add/finish all unit tests from previous phases and ensure they run green.
+
+Prompt
+
+- Run tests from CLI:
+
+  ```zsh
+  pytest -q
+  ```
+
+- Fix any failures. Ensure type/lint (if configured) pass. Avoid flaky test dependencies.
+
+Verification
+
+- All tests green.
+
+---
+
+## Phase 12 — Minimal docs
+
+Scope
+
+- Update README or add a minimal docs note explaining the new CLI command and capability preflight at a high level.
+
+Prompt
+
+- Keep the docs short and focused; reference the CLI help examples.
+
+Verification
+
+- Build passes; CLI help displays the new command.
+
+---
+
+## Finalization (all phases)
+
+- Post a short comment to Issue #14 summarizing what you implemented in your phase and any notable notes/risks. Keep it concise.
+- If you found opportunities for improvement beyond your phase, add them as separate notes in the issue (do not implement them).
+- Do not expand scope beyond your phase.
+
+## Run and debug tips
+
+- Prefer CLI over integrated terminals for reliability.
+- Capture logs when running commands:
+
+  ```zsh
+  uv run gnmibuddy.py <command> ... 2>&1 | tee /tmp/gnmibuddy_run.log
+  ```
+
+- For network/device tests, verify credentials and sandbox connectivity first.

--- a/src/cmd/commands/device/__init__.py
+++ b/src/cmd/commands/device/__init__.py
@@ -4,9 +4,11 @@
 from .info import device_info
 from .profile import device_profile
 from .list import device_list
+from .capabilities import device_capabilities
 
 __all__ = [
     "device_info",
     "device_profile",
     "device_list",
+    "device_capabilities",
 ]

--- a/src/cmd/commands/device/capabilities.py
+++ b/src/cmd/commands/device/capabilities.py
@@ -41,14 +41,21 @@ register_error_provider(Command.DEVICE_CAPABILITIES, error_provider)
 @register_command(Command.DEVICE_CAPABILITIES)
 @click.command(help=_get_command_help())
 @add_common_device_options
+@click.option(
+    "--all-models",
+    is_flag=True,
+    default=False,
+    help="Show all supported models (by default only required models with status are shown)",
+)
 @click.pass_context
 def device_capabilities(
-    ctx, device, output, devices, device_file, all_devices
+    ctx, device, output, devices, device_file, all_devices, all_models
 ):
     """Get gNMI capabilities from a network device"""
 
     def operation_func(device_obj, **kwargs):
-        return get_device_capabilities(device_obj)
+        # Pass flag positionally to avoid name mismatch across versions
+        return get_device_capabilities(device_obj, all_models)
 
     return execute_device_command(
         ctx=ctx,

--- a/src/cmd/commands/device/capabilities.py
+++ b/src/cmd/commands/device/capabilities.py
@@ -13,6 +13,17 @@ from src.cmd.registries.command_registry import (
 from src.collectors.capabilities import get_device_capabilities
 from src.cmd.examples.example_builder import ExampleBuilder, ExampleSet
 
+DESCRIPTION = """\b
+Get gNMI capabilities from a network device.
+
+By default, shows a focused summary of required OpenConfig models with status
+(ok/older/not_supported/unknown), the device's gNMI version, and encodings.
+Use --all-models to list every supported model and encoding.
+
+When a model is older than required, a warning is shown and some collectors may
+not work correctly. Consider updating the device's OpenConfig model/version.
+"""
+
 
 def device_capabilities_examples() -> ExampleSet:
     return ExampleBuilder.standard_command_examples(
@@ -27,7 +38,7 @@ def device_capabilities_examples() -> ExampleSet:
 
 
 def detailed_examples() -> str:
-    return device_capabilities_examples().for_help()
+    return f"{DESCRIPTION}\n{device_capabilities_examples().for_help()}"
 
 
 def _get_command_help() -> str:

--- a/src/cmd/commands/device/capabilities.py
+++ b/src/cmd/commands/device/capabilities.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Device capabilities command implementation"""
+import click
+
+from src.cmd.commands.base import execute_device_command
+from src.cmd.commands.decorators import add_common_device_options
+from src.cmd.schemas import Command, CommandGroup
+from src.cmd.error_providers import CommandErrorProvider
+from src.cmd.registries.command_registry import (
+    register_command,
+    register_error_provider,
+)
+from src.collectors.capabilities import get_device_capabilities
+from src.cmd.examples.example_builder import ExampleBuilder, ExampleSet
+
+
+def device_capabilities_examples() -> ExampleSet:
+    return ExampleBuilder.standard_command_examples(
+        command=f"{CommandGroup.DEVICE.group_name} {Command.DEVICE_CAPABILITIES.command_name}",
+        alias=f"d {Command.DEVICE_CAPABILITIES.command_name}",
+        device="R1",
+        detail_option=False,
+        batch_operations=True,
+        output_formats=True,
+        alias_examples=True,
+    )
+
+
+def detailed_examples() -> str:
+    return device_capabilities_examples().for_help()
+
+
+def _get_command_help() -> str:
+    return detailed_examples()
+
+
+error_provider = CommandErrorProvider(Command.DEVICE_CAPABILITIES)
+register_error_provider(Command.DEVICE_CAPABILITIES, error_provider)
+
+
+@register_command(Command.DEVICE_CAPABILITIES)
+@click.command(help=_get_command_help())
+@add_common_device_options
+@click.pass_context
+def device_capabilities(
+    ctx, device, output, devices, device_file, all_devices
+):
+    """Get gNMI capabilities from a network device"""
+
+    def operation_func(device_obj, **kwargs):
+        return get_device_capabilities(device_obj)
+
+    return execute_device_command(
+        ctx=ctx,
+        device=device,
+        devices=devices,
+        device_file=device_file,
+        all_devices=all_devices,
+        output=output,
+        operation_func=operation_func,
+        operation_name="capabilities",
+    )
+
+
+if __name__ == "__main__":
+    print(_get_command_help())

--- a/src/cmd/registries/command_modules.py
+++ b/src/cmd/registries/command_modules.py
@@ -45,6 +45,7 @@ COMMAND_MODULES: List[str] = [
     "src.cmd.commands.device.info",
     "src.cmd.commands.device.profile",
     "src.cmd.commands.device.list",
+    "src.cmd.commands.device.capabilities",
     # Network commands - Commands for network protocol analysis
     "src.cmd.commands.network.routing",
     "src.cmd.commands.network.interface",

--- a/src/cmd/schemas/command.py
+++ b/src/cmd/schemas/command.py
@@ -12,6 +12,10 @@ class Command(Enum):
     DEVICE_INFO = ("info", "Get system information from a network device")
     DEVICE_PROFILE = ("profile", "Get device profile and role information")
     DEVICE_LIST = ("list", "List all available devices in the inventory")
+    DEVICE_CAPABILITIES = (
+        "capabilities",
+        "Get gNMI capabilities from a network device",
+    )
 
     # Network commands
     NETWORK_ROUTING = (

--- a/src/cmd/schemas/commands.py
+++ b/src/cmd/schemas/commands.py
@@ -58,6 +58,10 @@ class CommandRegistry:
                 group=CommandGroup.DEVICE,
                 requires_device=False,
             ),
+            CommandInfo(
+                command=Command.DEVICE_CAPABILITIES,
+                group=CommandGroup.DEVICE,
+            ),
             # Network commands
             CommandInfo(
                 command=Command.NETWORK_ROUTING,

--- a/src/collectors/capabilities.py
+++ b/src/collectors/capabilities.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Collector for device gNMI Capabilities.
+
+Provides a function to retrieve and normalize device capabilities
+using the CapabilityService and return a NetworkOperationResult
+that the CLI can format consistently.
+"""
+from typing import Any, Dict, List
+
+from src.schemas.models import Device
+from src.schemas.responses import (
+    NetworkOperationResult,
+    OperationStatus,
+    ErrorResponse,
+)
+from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
+from src.gnmi.capabilities.service import CapabilityService
+from src.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _serialize_models(models) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for m in models or []:
+        out.append(
+            {
+                "name": getattr(m, "name", None),
+                "version": getattr(m, "version", None),
+                "organization": getattr(m, "organization", None),
+            }
+        )
+    return out
+
+
+def get_device_capabilities(device: Device) -> NetworkOperationResult:
+    """
+    Retrieve device gNMI capabilities.
+
+    Args:
+        device: Target device
+
+    Returns:
+        NetworkOperationResult with capabilities data or error
+    """
+    logger.debug("Fetching capabilities for device %s", device.name)
+
+    try:
+        repo = DeviceCapabilitiesRepository()
+        service = CapabilityService(repo)
+        caps = service.get_or_fetch(device)
+
+        data: Dict[str, Any] = {
+            "gnmi_version": caps.gnmi_version,
+            "supported_encodings": list(caps.encodings or []),
+            "supported_models": _serialize_models(caps.models),
+        }
+
+        logger.info(
+            "Capabilities retrieved for %s: %d models, %d encodings",
+            device.name,
+            len(caps.models or []),
+            len(caps.encodings or []),
+        )
+
+        return NetworkOperationResult(
+            device_name=device.name,
+            ip_address=device.ip_address,
+            nos=getattr(device.nos, "value", str(device.nos)),
+            operation_type="capabilities",
+            status=OperationStatus.SUCCESS,
+            data=data,
+        )
+
+    except Exception as e:
+        logger.error("Error fetching capabilities from %s: %s", device.name, e)
+        return NetworkOperationResult(
+            device_name=device.name,
+            ip_address=device.ip_address,
+            nos=getattr(device.nos, "value", str(device.nos)),
+            operation_type="capabilities",
+            status=OperationStatus.FAILED,
+            error_response=ErrorResponse(
+                type="CAPABILITIES_ERROR", message=str(e)
+            ),
+        )

--- a/src/collectors/capabilities.py
+++ b/src/collectors/capabilities.py
@@ -17,6 +17,7 @@ from src.schemas.responses import (
 from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
 from src.gnmi.capabilities.service import CapabilityService
 from src.gnmi.capabilities.inspector import RequestInspector
+from src.gnmi.capabilities.constants import REQUIRED_OPENCONFIG_MODELS
 from src.gnmi.capabilities.version import safe_compare
 from src.logging import get_logger
 
@@ -67,11 +68,10 @@ def get_device_capabilities(
             inspector = RequestInspector()
             # Build requirements from known mapping without needing user paths
             required = [
-                # Use MAPPING items to build ModelRequirement list
-                # Ensures CLI validation matches preflight logic
+                # Use centralized REQUIRED_OPENCONFIG_MODELS
                 *(
                     inspector.infer_requirements([f"{name}:/"])
-                    for name in inspector.MAPPING.keys()
+                    for name in REQUIRED_OPENCONFIG_MODELS.keys()
                 )
             ]
             # Flatten the list of lists

--- a/src/collectors/capabilities.py
+++ b/src/collectors/capabilities.py
@@ -140,7 +140,7 @@ def get_device_capabilities(
         return NetworkOperationResult(
             device_name=device.name,
             ip_address=device.ip_address,
-            nos=getattr(device.nos, "value", str(device.nos)),
+            nos=device.nos,
             operation_type="capabilities",
             status=OperationStatus.SUCCESS,
             data=data,
@@ -151,7 +151,7 @@ def get_device_capabilities(
         return NetworkOperationResult(
             device_name=device.name,
             ip_address=device.ip_address,
-            nos=getattr(device.nos, "value", str(device.nos)),
+            nos=device.nos,
             operation_type="capabilities",
             status=OperationStatus.FAILED,
             error_response=ErrorResponse(

--- a/src/collectors/capabilities.py
+++ b/src/collectors/capabilities.py
@@ -99,25 +99,28 @@ def get_device_capabilities(
                     else:
                         status = "ok"
 
+                # Build a clear, user-facing message for each status
+                if status == "ok":
+                    msg = (
+                        "Model present and meets the required minimum version"
+                    )
+                elif status == "older":
+                    msg = (
+                        f"Model present but older than required (device has {device_ver or 'unknown'} < {req.minimum_version}); "
+                        "some collectors may not work correctly. Consider updating the device's OpenConfig model/version."
+                    )
+                elif status == "not_supported":
+                    msg = "Model not supported on device"
+                else:
+                    msg = "Model version comparison unknown"
+
                 focused.append(
                     {
                         "name": req.name,
                         "required_min_version": req.minimum_version,
                         "device_version": device_ver,
                         "status": status,
-                        "message": (
-                            "Model present and meets minimum version"
-                            if status == "ok"
-                            else (
-                                "Model present but older than required"
-                                if status == "older"
-                                else (
-                                    "Model not supported on device"
-                                    if status == "not_supported"
-                                    else "Model version comparison unknown"
-                                )
-                            )
-                        ),
+                        "message": msg,
                     }
                 )
 

--- a/src/collectors/capabilities.py
+++ b/src/collectors/capabilities.py
@@ -6,7 +6,7 @@ Provides a function to retrieve and normalize device capabilities
 using the CapabilityService and return a NetworkOperationResult
 that the CLI can format consistently.
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from src.schemas.models import Device
 from src.schemas.responses import (
@@ -16,6 +16,8 @@ from src.schemas.responses import (
 )
 from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
 from src.gnmi.capabilities.service import CapabilityService
+from src.gnmi.capabilities.inspector import RequestInspector
+from src.gnmi.capabilities.version import safe_compare
 from src.logging import get_logger
 
 logger = get_logger(__name__)
@@ -34,7 +36,9 @@ def _serialize_models(models) -> List[Dict[str, Any]]:
     return out
 
 
-def get_device_capabilities(device: Device) -> NetworkOperationResult:
+def get_device_capabilities(
+    device: Device, show_all_models: bool = False
+) -> NetworkOperationResult:
     """
     Retrieve device gNMI capabilities.
 
@@ -51,11 +55,77 @@ def get_device_capabilities(device: Device) -> NetworkOperationResult:
         service = CapabilityService(repo)
         caps = service.get_or_fetch(device)
 
-        data: Dict[str, Any] = {
-            "gnmi_version": caps.gnmi_version,
-            "supported_encodings": list(caps.encodings or []),
-            "supported_models": _serialize_models(caps.models),
-        }
+        if show_all_models:
+            # Full raw-ish output
+            data: Dict[str, Any] = {
+                "gnmi_version": caps.gnmi_version,
+                "supported_encodings": list(caps.encodings or []),
+                "supported_models": _serialize_models(caps.models),
+            }
+        else:
+            # Focused view: only models the tool cares about + status
+            inspector = RequestInspector()
+            # Build requirements from known mapping without needing user paths
+            required = [
+                # Use MAPPING items to build ModelRequirement list
+                # Ensures CLI validation matches preflight logic
+                *(
+                    inspector.infer_requirements([f"{name}:/"])
+                    for name in inspector.MAPPING.keys()
+                )
+            ]
+            # Flatten the list of lists
+            flat_required = [r for sub in required for r in sub]
+
+            # Determine device status for each required model
+            focused: List[Dict[str, Optional[str]]] = []
+            for req in flat_required:
+                # Find device's model version for this requirement
+                device_ver: Optional[str] = None
+                for m in caps.models:
+                    if m.name == req.name:
+                        device_ver = m.version
+                        break
+
+                status: str
+                if device_ver is None:
+                    status = "not_supported"
+                else:
+                    cmp = safe_compare(device_ver, req.minimum_version)
+                    if cmp is None or req.minimum_version is None:
+                        status = "unknown"
+                    elif cmp < 0:
+                        status = "older"
+                    else:
+                        status = "ok"
+
+                focused.append(
+                    {
+                        "name": req.name,
+                        "required_min_version": req.minimum_version,
+                        "device_version": device_ver,
+                        "status": status,
+                        "message": (
+                            "Model present and meets minimum version"
+                            if status == "ok"
+                            else (
+                                "Model present but older than required"
+                                if status == "older"
+                                else (
+                                    "Model not supported on device"
+                                    if status == "not_supported"
+                                    else "Model version comparison unknown"
+                                )
+                            )
+                        ),
+                    }
+                )
+
+            data = {
+                "gnmi_version": caps.gnmi_version,
+                "encodings": list(caps.encodings or []),
+                "required_models": focused,
+            }
 
         logger.info(
             "Capabilities retrieved for %s: %d models, %d encodings",

--- a/src/collectors/logs.py
+++ b/src/collectors/logs.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 from src.schemas.models import Device
 from src.gnmi.client import get_gnmi_data
 from src.gnmi.parameters import GnmiRequest
+from src.gnmi.capabilities.encoding import GnmiEncoding
 from src.processors.logs.filter import filter_logs
 from src.schemas.responses import (
     ErrorResponse,
@@ -85,7 +86,7 @@ def get_logs(
     logger.debug("Generated log query: %s", log_query)
 
     # Create a GnmiRequest with the appropriate parameters for logs
-    log_request = GnmiRequest(path=[log_query], encoding="ascii")
+    log_request = GnmiRequest(path=[log_query], encoding=GnmiEncoding.ASCII)
 
     response = get_gnmi_data(device=device, request=log_request)
     logger.debug(

--- a/src/collectors/vpn.py
+++ b/src/collectors/vpn.py
@@ -21,6 +21,7 @@ from src.processors.protocols.vrf import (
 )
 from src.gnmi.client import get_gnmi_data
 from src.gnmi.parameters import GnmiRequest
+from src.gnmi.capabilities.encoding import GnmiEncoding
 from src.utils.vrf_utils import (
     get_non_default_vrf_names,
     DEFAULT_INTERNAL_VRFS,
@@ -206,7 +207,7 @@ def _get_vrf_details(
     )
 
     vrf_details_request = GnmiRequest(
-        path=vrf_path_queries, encoding="json_ietf"
+        path=vrf_path_queries, encoding=GnmiEncoding.JSON_IETF
     )
 
     response = get_gnmi_data(device, vrf_details_request)

--- a/src/gnmi/capabilities/__init__.py
+++ b/src/gnmi/capabilities/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Capabilities package for gNMI model/encoding checks and services."""
+
+from . import (
+    models,
+    version,
+    repository,
+    service,
+    inspector,
+    encoding,
+    checker,
+    errors,
+)  # noqa: F401
+
+__all__ = [
+    "models",
+    "version",
+    "repository",
+    "service",
+    "inspector",
+    "encoding",
+    "checker",
+    "errors",
+]

--- a/src/gnmi/capabilities/__init__.py
+++ b/src/gnmi/capabilities/__init__.py
@@ -10,6 +10,7 @@ from . import (
     encoding,
     checker,
     errors,
+    constants,
 )  # noqa: F401
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "encoding",
     "checker",
     "errors",
+    "constants",
 ]

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Capability checker orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional, Tuple
+
+from .errors import CapabilityError
+from .models import DeviceCapabilities, ModelRequirement
+from .service import CapabilityService
+from .inspector import RequestInspector
+from .encoding import EncodingPolicy
+
+
+@dataclass
+class CapabilityCheckResult:
+    success: bool
+    warnings: List[str] = field(default_factory=list)
+    selected_encoding: Optional[str] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+
+    def is_failure(self) -> bool:
+        return not self.success
+
+
+class CapabilityChecker:
+    def __init__(
+        self,
+        service: CapabilityService,
+        version_cmp: Callable[[Optional[str], Optional[str]], Optional[int]],
+        encoding_policy: EncodingPolicy,
+    ) -> None:
+        self.service = service
+        self.version_cmp = version_cmp
+        self.encoding_policy = encoding_policy
+        self.inspector = RequestInspector()
+
+    def check(
+        self, device, paths: List[str], requested_encoding: Optional[str]
+    ) -> CapabilityCheckResult:
+        caps = self.service.get_or_fetch(device)
+
+        # Encoding selection
+        selected, used_fallback = self.encoding_policy.choose_supported(
+            requested_encoding, caps.encodings
+        )
+        if selected is None:
+            return CapabilityCheckResult(
+                success=False,
+                error_type=CapabilityError.ENCODING_NOT_SUPPORTED.value,
+                error_message=(
+                    f"Requested encoding '{requested_encoding}' is not supported by device"
+                ),
+            )
+
+        warnings: List[str] = []
+
+        # Infer requirements
+        requirements = self.inspector.infer_requirements(paths)
+        for req in requirements:
+            present, older = caps.has_model(req, self.version_cmp)
+            if not present:
+                min_ver = (
+                    f">={req.minimum_version}" if req.minimum_version else ""
+                )
+                return CapabilityCheckResult(
+                    success=False,
+                    error_type=CapabilityError.MODEL_NOT_SUPPORTED.value,
+                    error_message=(
+                        f"Required model '{req.name}{min_ver}' not supported by device"
+                    ),
+                )
+            if older:
+                warnings.append(
+                    f"Model '{req.name}' is older than required (device has < {req.minimum_version})"
+                )
+
+        return CapabilityCheckResult(
+            success=True,
+            warnings=warnings,
+            selected_encoding=selected,
+        )

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -78,13 +78,14 @@ class CapabilityChecker:
                     if m.matches(req.name):
                         device_ver = m.version
                         break
+                guidance = "; some collectors may not work correctly. Consider updating the device's OpenConfig model/version."
                 if device_ver:
                     warnings.append(
-                        f"Model '{req.name}' is older than required (device has {device_ver} < {req.minimum_version})"
+                        f"Model '{req.name}' is older than required (device has {device_ver} < {req.minimum_version}){guidance}"
                     )
                 else:
                     warnings.append(
-                        f"Model '{req.name}' is older than required (device has < {req.minimum_version})"
+                        f"Model '{req.name}' is older than required (device has < {req.minimum_version}){guidance}"
                     )
 
         return CapabilityCheckResult(

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional
 
 from .errors import CapabilityError
-from .models import DeviceCapabilities, ModelRequirement
 from .service import CapabilityService
 from .inspector import RequestInspector
 from .encoding import EncodingPolicy

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Callable, List, Optional
 
 from .errors import CapabilityError
+from .models import DeviceCapabilities
 from .service import CapabilityService
 from .inspector import RequestInspector
 from .encoding import EncodingPolicy
@@ -40,6 +41,70 @@ class CapabilityChecker:
     ) -> CapabilityCheckResult:
         caps = self.service.get_or_fetch(device)
 
+        # Encoding selection
+        selected, used_fallback = self.encoding_policy.choose_supported(
+            requested_encoding, caps.encodings
+        )
+        if selected is None:
+            return CapabilityCheckResult(
+                success=False,
+                error_type=CapabilityError.ENCODING_NOT_SUPPORTED.value,
+                error_message=(
+                    f"Requested encoding '{requested_encoding}' is not supported by device"
+                ),
+            )
+
+        warnings: List[str] = []
+
+        # Infer requirements
+        requirements = self.inspector.infer_requirements(paths)
+        for req in requirements:
+            present, older = caps.has_model(req, self.version_cmp)
+            if not present:
+                min_ver = (
+                    f">={req.minimum_version}" if req.minimum_version else ""
+                )
+                return CapabilityCheckResult(
+                    success=False,
+                    error_type=CapabilityError.MODEL_NOT_SUPPORTED.value,
+                    error_message=(
+                        f"Required model '{req.name}{min_ver}' not supported by device"
+                    ),
+                )
+            if older:
+                # Try to include the device's actual version in the warning
+                device_ver = None
+                for m in caps.models:
+                    if m.matches(req.name):
+                        device_ver = m.version
+                        break
+                guidance = "; some collectors may not work correctly. Consider updating the device's OpenConfig model/version."
+                if device_ver:
+                    warnings.append(
+                        f"Model '{req.name}' is older than required (device has {device_ver} < {req.minimum_version}){guidance}"
+                    )
+                else:
+                    warnings.append(
+                        f"Model '{req.name}' is older than required (device has < {req.minimum_version}){guidance}"
+                    )
+
+        return CapabilityCheckResult(
+            success=True,
+            warnings=warnings,
+            selected_encoding=selected,
+        )
+
+    def check_with_caps(
+        self,
+        caps: DeviceCapabilities,
+        paths: List[str],
+        requested_encoding: Optional[str],
+    ) -> CapabilityCheckResult:
+        """Check capabilities using a provided, already-fetched DeviceCapabilities.
+
+        This avoids any network calls and supports a workflow where capabilities
+        are prefetched during inventory initialization.
+        """
         # Encoding selection
         selected, used_fallback = self.encoding_policy.choose_supported(
             requested_encoding, caps.encodings

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -72,9 +72,20 @@ class CapabilityChecker:
                     ),
                 )
             if older:
-                warnings.append(
-                    f"Model '{req.name}' is older than required (device has < {req.minimum_version})"
-                )
+                # Try to include the device's actual version in the warning
+                device_ver = None
+                for m in caps.models:
+                    if m.matches(req.name):
+                        device_ver = m.version
+                        break
+                if device_ver:
+                    warnings.append(
+                        f"Model '{req.name}' is older than required (device has {device_ver} < {req.minimum_version})"
+                    )
+                else:
+                    warnings.append(
+                        f"Model '{req.name}' is older than required (device has < {req.minimum_version})"
+                    )
 
         return CapabilityCheckResult(
             success=True,

--- a/src/gnmi/capabilities/checker.py
+++ b/src/gnmi/capabilities/checker.py
@@ -9,7 +9,7 @@ from .errors import CapabilityError
 from .models import DeviceCapabilities
 from .service import CapabilityService
 from .inspector import RequestInspector
-from .encoding import EncodingPolicy
+from .encoding import EncodingPolicy, GnmiEncoding
 
 
 @dataclass
@@ -37,7 +37,10 @@ class CapabilityChecker:
         self.inspector = RequestInspector()
 
     def check(
-        self, device, paths: List[str], requested_encoding: Optional[str]
+        self,
+        device,
+        paths: List[str],
+        requested_encoding: Optional[GnmiEncoding | str],
     ) -> CapabilityCheckResult:
         caps = self.service.get_or_fetch(device)
 
@@ -55,6 +58,16 @@ class CapabilityChecker:
             )
 
         warnings: List[str] = []
+        if (
+            used_fallback
+            and requested_encoding is not None
+            and selected is not None
+        ):
+            req_str = str(requested_encoding)
+            sel_str = str(selected)
+            warnings.append(
+                f"Requested encoding '{req_str}' not supported; using fallback '{sel_str}'."
+            )
 
         # Infer requirements
         requirements = self.inspector.infer_requirements(paths)
@@ -91,14 +104,14 @@ class CapabilityChecker:
         return CapabilityCheckResult(
             success=True,
             warnings=warnings,
-            selected_encoding=selected,
+            selected_encoding=str(selected),
         )
 
     def check_with_caps(
         self,
         caps: DeviceCapabilities,
         paths: List[str],
-        requested_encoding: Optional[str],
+        requested_encoding: Optional[GnmiEncoding | str],
     ) -> CapabilityCheckResult:
         """Check capabilities using a provided, already-fetched DeviceCapabilities.
 
@@ -119,6 +132,16 @@ class CapabilityChecker:
             )
 
         warnings: List[str] = []
+        if (
+            used_fallback
+            and requested_encoding is not None
+            and selected is not None
+        ):
+            req_str = str(requested_encoding)
+            sel_str = str(selected)
+            warnings.append(
+                f"Requested encoding '{req_str}' not supported; using fallback '{sel_str}'."
+            )
 
         # Infer requirements
         requirements = self.inspector.infer_requirements(paths)
@@ -155,5 +178,5 @@ class CapabilityChecker:
         return CapabilityCheckResult(
             success=True,
             warnings=warnings,
-            selected_encoding=selected,
+            selected_encoding=str(selected),
         )

--- a/src/gnmi/capabilities/constants.py
+++ b/src/gnmi/capabilities/constants.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Shared constants for gNMI capabilities.
+
+Defines the set of OpenConfig models that gNMI Buddy requires or cares about
+across the codebase, with their minimum acceptable versions. Centralizing this
+mapping avoids duplication and makes it easy to update requirements.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+# Map of OpenConfig module name -> minimum required version
+# Keep values as strings to allow semantic/loose comparison elsewhere.
+REQUIRED_OPENCONFIG_MODELS: Dict[str, str] = {
+    "openconfig-system": "0.17.1",
+    "openconfig-interfaces": "3.0.0",
+    "openconfig-network-instance": "1.3.0",
+}
+
+__all__ = ["REQUIRED_OPENCONFIG_MODELS"]

--- a/src/gnmi/capabilities/encoding.py
+++ b/src/gnmi/capabilities/encoding.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Encoding normalization and selection policy."""
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+
+class EncodingPolicy:
+    """Canonicalize encodings and choose supported fallbacks."""
+
+    CANONICAL = {
+        "JSON_IETF": "json_ietf",
+        "JSON": "json",
+        "ASCII": "ascii",
+        # lower-case variants
+        "json_ietf": "json_ietf",
+        "json": "json",
+        "ascii": "ascii",
+    }
+
+    def normalize(self, encoding: Optional[str]) -> Optional[str]:
+        if encoding is None:
+            return None
+        return self.CANONICAL.get(
+            encoding, self.CANONICAL.get(encoding.upper())
+        )
+
+    def choose_supported(
+        self, requested: Optional[str], supported: List[str]
+    ) -> Tuple[Optional[str], bool]:
+        """Return (selected_encoding, used_fallback)."""
+        norm_supported = {self.normalize(e) for e in supported}
+
+        req = self.normalize(requested) if requested else None
+        if req is None:
+            # No request -> prefer best available
+            for candidate in ("json_ietf", "json", "ascii"):
+                if candidate in norm_supported:
+                    return candidate, False
+            return None, False
+
+        if req in norm_supported:
+            return req, False
+
+        # fallback order: be conservative and only allow fallback to ASCII
+        # This matches expected behavior in tests where json_ietf -> json is NOT allowed
+        fallbacks = {
+            "json_ietf": ["ascii"],
+            "json": ["ascii"],
+            "ascii": [],
+        }
+        for candidate in fallbacks.get(req, []):
+            if candidate in norm_supported:
+                return candidate, True
+        return None, False

--- a/src/gnmi/capabilities/encoding.py
+++ b/src/gnmi/capabilities/encoding.py
@@ -1,55 +1,83 @@
 #!/usr/bin/env python3
-"""Encoding normalization and selection policy."""
+"""Encoding normalization and selection policy with Enum support."""
 from __future__ import annotations
 
-from typing import List, Optional, Tuple
+from enum import Enum
+from typing import Optional, Tuple, Union, Sequence
+
+
+class GnmiEncoding(Enum):
+    JSON_IETF = "json_ietf"
+    JSON = "json"
+    ASCII = "ascii"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.value
+
+    @classmethod
+    def from_any(
+        cls, value: Optional[Union[str, "GnmiEncoding"]]
+    ) -> Optional["GnmiEncoding"]:
+        """Parse various inputs to a GnmiEncoding enum.
+
+        - If enum is provided, return it.
+        - If string is provided, case-normalize and map to enum.
+        - Otherwise return None.
+        """
+        if value is None:
+            return None
+        if isinstance(value, GnmiEncoding):
+            return value
+        s = str(value).strip().lower()
+        if s == "json_ietf":
+            return GnmiEncoding.JSON_IETF
+        if s == "json":
+            return GnmiEncoding.JSON
+        if s == "ascii":
+            return GnmiEncoding.ASCII
+        return None
 
 
 class EncodingPolicy:
-    """Canonicalize encodings and choose supported fallbacks."""
+    """Normalize inputs to enums and choose supported fallbacks (as enums)."""
 
-    CANONICAL = {
-        "JSON_IETF": "json_ietf",
-        "JSON": "json",
-        "ASCII": "ascii",
-        # lower-case variants
-        "json_ietf": "json_ietf",
-        "json": "json",
-        "ascii": "ascii",
-    }
-
-    def normalize(self, encoding: Optional[str]) -> Optional[str]:
-        if encoding is None:
-            return None
-        return self.CANONICAL.get(
-            encoding, self.CANONICAL.get(encoding.upper())
-        )
+    def normalize(
+        self, encoding: Optional[Union[str, GnmiEncoding]]
+    ) -> Optional[GnmiEncoding]:
+        return GnmiEncoding.from_any(encoding)
 
     def choose_supported(
-        self, requested: Optional[str], supported: List[str]
-    ) -> Tuple[Optional[str], bool]:
-        """Return (selected_encoding, used_fallback)."""
-        norm_supported = {self.normalize(e) for e in supported}
+        self,
+        requested: Optional[Union[str, GnmiEncoding]],
+        supported: Sequence[Union[str, GnmiEncoding]],
+    ) -> Tuple[Optional[GnmiEncoding], bool]:
+        """Return (selected_encoding_enum, used_fallback)."""
+        sup: set[GnmiEncoding] = {
+            e for e in (self.normalize(x) for x in supported) if e is not None
+        }
 
-        req = self.normalize(requested) if requested else None
+        req = self.normalize(requested) if requested is not None else None
         if req is None:
             # No request -> prefer best available
-            for candidate in ("json_ietf", "json", "ascii"):
-                if candidate in norm_supported:
+            for candidate in (
+                GnmiEncoding.JSON_IETF,
+                GnmiEncoding.JSON,
+                GnmiEncoding.ASCII,
+            ):
+                if candidate in sup:
                     return candidate, False
             return None, False
 
-        if req in norm_supported:
+        if req in sup:
             return req, False
 
-        # fallback order: be conservative and only allow fallback to ASCII
-        # This matches expected behavior in tests where json_ietf -> json is NOT allowed
-        fallbacks = {
-            "json_ietf": ["ascii"],
-            "json": ["ascii"],
-            "ascii": [],
+        # Conservative fallback policy: only allow fallback to ASCII
+        fallbacks: dict[GnmiEncoding, tuple[GnmiEncoding, ...]] = {
+            GnmiEncoding.JSON_IETF: (GnmiEncoding.ASCII,),
+            GnmiEncoding.JSON: (GnmiEncoding.ASCII,),
+            GnmiEncoding.ASCII: (),
         }
-        for candidate in fallbacks.get(req, []):
-            if candidate in norm_supported:
-                return candidate, True
+        for cand in fallbacks.get(req, ()):
+            if cand in sup:
+                return cand, True
         return None, False

--- a/src/gnmi/capabilities/errors.py
+++ b/src/gnmi/capabilities/errors.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Error types for capability checks."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CapabilityError(Enum):
+    MODEL_NOT_SUPPORTED = "MODEL_NOT_SUPPORTED"
+    ENCODING_NOT_SUPPORTED = "ENCODING_NOT_SUPPORTED"
+
+
+__all__ = ["CapabilityError"]

--- a/src/gnmi/capabilities/inspector.py
+++ b/src/gnmi/capabilities/inspector.py
@@ -5,16 +5,14 @@ from __future__ import annotations
 from typing import List
 
 from .models import ModelRequirement
+from .constants import REQUIRED_OPENCONFIG_MODELS
 
 
 class RequestInspector:
     """Infers required OpenConfig models from paths."""
 
-    MAPPING = {
-        "openconfig-system": "0.17.1",
-        "openconfig-interfaces": "3.0.0",
-        "openconfig-network-instance": "1.3.0",
-    }
+    # Backwards-compat attribute name used elsewhere; alias to central constant
+    MAPPING = REQUIRED_OPENCONFIG_MODELS
 
     def infer_requirements(self, paths: List[str]) -> List[ModelRequirement]:
         seen = {}

--- a/src/gnmi/capabilities/inspector.py
+++ b/src/gnmi/capabilities/inspector.py
@@ -12,7 +12,7 @@ class RequestInspector:
 
     MAPPING = {
         "openconfig-system": "0.17.1",
-        "openconfig-interfaces": "4.0.0",
+        "openconfig-interfaces": "3.0.0",
         "openconfig-network-instance": "1.3.0",
     }
 

--- a/src/gnmi/capabilities/inspector.py
+++ b/src/gnmi/capabilities/inspector.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Infer model requirements from request paths."""
+from __future__ import annotations
+
+from typing import List
+
+from .models import ModelRequirement
+
+
+class RequestInspector:
+    """Infers required OpenConfig models from paths."""
+
+    MAPPING = {
+        "openconfig-system": "0.17.1",
+        "openconfig-interfaces": "4.0.0",
+        "openconfig-network-instance": "1.3.0",
+    }
+
+    def infer_requirements(self, paths: List[str]) -> List[ModelRequirement]:
+        seen = {}
+        for p in paths or []:
+            if ":" in p:
+                module, _rest = p.split(":", 1)
+            else:
+                # Allow forms like "openconfig-system/system" (no colon)
+                module = p.split("/")[0]
+            module = module.strip()
+            if module in self.MAPPING and module not in seen:
+                seen[module] = ModelRequirement(
+                    name=module, minimum_version=self.MAPPING[module]
+                )
+        return list(seen.values())

--- a/src/gnmi/capabilities/models.py
+++ b/src/gnmi/capabilities/models.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Domain models for gNMI device capabilities.
+
+Pure data objects (no external side-effects) to represent OpenConfig models,
+requirements, and device capability sets. Avoid using dicts to encapsulate
+behavior—use classes with clear methods and representations.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class ModelIdentifier:
+    """Represents a supported YANG model on the device."""
+
+    name: str
+    version: Optional[str] = None
+    organization: Optional[str] = None
+
+    def normalized_version(self) -> Optional[str]:
+        """Return a normalized string form of version if present.
+
+        Normalization is delegated to a higher-level component; this method just
+        returns the raw version string (kept for interface clarity/extension).
+        """
+        return self.version
+
+    def matches(self, name: str) -> bool:
+        """Check if this model identifier matches by name (case-sensitive)."""
+        return self.name == name
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"ModelIdentifier(name={self.name!r}, version={self.version!r}, "
+            f"organization={self.organization!r})"
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        ver = f"@{self.version}" if self.version else ""
+        return f"{self.name}{ver}"
+
+
+@dataclass(frozen=True)
+class ModelRequirement:
+    """Represents a requirement for a YANG model with an optional min version."""
+
+    name: str
+    minimum_version: Optional[str] = None
+
+    def requires_version(self) -> bool:
+        return bool(self.minimum_version)
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"ModelRequirement(name={self.name!r}, minimum_version={self.minimum_version!r})"
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        if self.minimum_version:
+            return f"{self.name}>={self.minimum_version}"
+        return self.name
+
+
+@dataclass
+class DeviceCapabilities:
+    """Device capability set returned by Capabilities RPC.
+
+    Attributes:
+        models: list of ModelIdentifier supported by the device
+        encodings: list of supported encodings (already normalized if needed)
+        gnmi_version: optional gNMI version string
+    """
+
+    models: List[ModelIdentifier]
+    encodings: List[str]
+    gnmi_version: Optional[str] = None
+
+    def has_model(
+        self,
+        req: ModelRequirement,
+        version_cmp: Callable[[Optional[str], Optional[str]], Optional[int]],
+    ) -> Tuple[bool, bool]:
+        """Check if a required model is present and if it's older than minimum.
+
+        Returns a tuple (present, older_than_min):
+          - present: True if a model with the required name exists on device
+          - older_than_min: True if present but version < minimum_version
+
+        version_cmp should return -1, 0, 1 for a<b, a==b, a>b respectively,
+        or None if comparison is not possible.
+        """
+        present = False
+        older_than_min = False
+
+        for model in self.models:
+            if not model.matches(req.name):
+                continue
+            present = True
+
+            if req.requires_version():
+                cmp = version_cmp(model.version, req.minimum_version)
+                if cmp is None:
+                    # Unknown comparison; treat as not older to avoid false failures
+                    older_than_min = False
+                else:
+                    older_than_min = cmp < 0
+            break
+
+        return present, older_than_min
+
+    def supports_encoding(
+        self,
+        encoding: str,
+        normalize: Callable[[Optional[str]], Optional[str]],
+    ) -> bool:
+        """Return True if the requested encoding is supported by device.
+
+        The normalize function canonicalizes input and capability encodings
+        into a common form (e.g., JSON_IETF -> json_ietf).
+        """
+        if encoding is None:
+            return True
+        enc = normalize(encoding)
+        supported = {normalize(e) for e in self.encodings}
+        return enc in supported
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"DeviceCapabilities(models={self.models!r}, encodings={self.encodings!r}, "
+            f"gnmi_version={self.gnmi_version!r})"
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        models_str = ", ".join(str(m) for m in self.models)
+        encs = ", ".join(self.encodings)
+        return f"models=[{models_str}] encodings=[{encs}] gnmi={self.gnmi_version or '-'}"

--- a/src/gnmi/capabilities/models.py
+++ b/src/gnmi/capabilities/models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
+from .encoding import GnmiEncoding
 
 
 @dataclass(frozen=True)
@@ -72,7 +73,7 @@ class DeviceCapabilities:
     """
 
     models: List[ModelIdentifier]
-    encodings: List[str]
+    encodings: List[GnmiEncoding]
     gnmi_version: Optional[str] = None
 
     def has_model(
@@ -108,21 +109,11 @@ class DeviceCapabilities:
 
         return present, older_than_min
 
-    def supports_encoding(
-        self,
-        encoding: str,
-        normalize: Callable[[Optional[str]], Optional[str]],
-    ) -> bool:
-        """Return True if the requested encoding is supported by device.
-
-        The normalize function canonicalizes input and capability encodings
-        into a common form (e.g., JSON_IETF -> json_ietf).
-        """
+    def supports_encoding(self, encoding: Optional[GnmiEncoding]) -> bool:
+        """Return True if the requested enum encoding is supported by device."""
         if encoding is None:
             return True
-        enc = normalize(encoding)
-        supported = {normalize(e) for e in self.encodings}
-        return enc in supported
+        return encoding in set(self.encodings)
 
     def __repr__(self) -> str:  # pragma: no cover - trivial
         return (
@@ -132,5 +123,5 @@ class DeviceCapabilities:
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         models_str = ", ".join(str(m) for m in self.models)
-        encs = ", ".join(self.encodings)
+        encs = ", ".join(str(e) for e in self.encodings)
         return f"models=[{models_str}] encodings=[{encs}] gnmi={self.gnmi_version or '-'}"

--- a/src/gnmi/capabilities/repository.py
+++ b/src/gnmi/capabilities/repository.py
@@ -8,10 +8,17 @@ from .models import DeviceCapabilities
 
 
 class DeviceCapabilitiesRepository:
-    """Simple in-memory cache keyed by a stable device key."""
+    """Simple in-memory cache keyed by a stable device key.
 
-    def __init__(self) -> None:
-        self._cache: Dict[str, DeviceCapabilities] = {}
+    Designed to behave like a process-wide shared cache so that different
+    components see the same capabilities once loaded.
+    """
+
+    # Shared cache across all instances
+    _cache: Dict[str, DeviceCapabilities] = {}
+
+    def __init__(self) -> None:  # do not reset the shared cache
+        pass
 
     @staticmethod
     def make_key(device: Device) -> str:

--- a/src/gnmi/capabilities/repository.py
+++ b/src/gnmi/capabilities/repository.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""In-memory repository for caching device capabilities."""
+from __future__ import annotations
+
+from typing import Dict, Optional
+from src.schemas.models import Device
+from .models import DeviceCapabilities
+
+
+class DeviceCapabilitiesRepository:
+    """Simple in-memory cache keyed by a stable device key."""
+
+    def __init__(self) -> None:
+        self._cache: Dict[str, DeviceCapabilities] = {}
+
+    @staticmethod
+    def make_key(device: Device) -> str:
+        nos = getattr(device, "nos", "unknown")
+        ip = getattr(device, "ip_address", "")
+        port = getattr(device, "port", 0)
+        return f"{nos}:{ip}:{port}"
+
+    def get(self, device: Device) -> Optional[DeviceCapabilities]:
+        return self._cache.get(self.make_key(device))
+
+    def set(self, device: Device, caps: DeviceCapabilities) -> None:
+        self._cache[self.make_key(device)] = caps
+
+    def has(self, device: Device) -> bool:
+        return self.make_key(device) in self._cache
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/src/gnmi/capabilities/service.py
+++ b/src/gnmi/capabilities/service.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Capability service using gNMI Capabilities RPC with caching."""
+from __future__ import annotations
+
+from typing import List, Dict, Any
+
+from pygnmi.client import gNMIclient
+
+from src.schemas.models import Device
+from .models import DeviceCapabilities, ModelIdentifier
+from .repository import DeviceCapabilitiesRepository
+
+
+class CapabilityService:
+    def __init__(self, repo: DeviceCapabilitiesRepository) -> None:
+        self.repo = repo
+
+    def get_or_fetch(self, device: Device) -> DeviceCapabilities:
+        cached = self.repo.get(device)
+        if cached:
+            return cached
+        caps = self._fetch(device)
+        self.repo.set(device, caps)
+        return caps
+
+    def _fetch(self, device: Device) -> DeviceCapabilities:
+        # Build connection params locally to avoid circular import with gnmi.client
+        params = {
+            "target": (device.ip_address, device.port),
+            "username": device.username,
+            "password": device.password,
+            "insecure": device.insecure,
+            "path_cert": device.path_cert,
+            "path_key": device.path_key,
+            "path_root": device.path_root,
+            "override": device.override,
+            "skip_verify": device.skip_verify,
+            "gnmi_timeout": device.gnmi_timeout,
+            "grpc_options": device.grpc_options,
+            "show_diff": device.show_diff,
+        }
+        models: List[ModelIdentifier] = []
+        encodings: List[str] = []
+        gnmi_version: str | None = None
+
+        def normalize_encoding(e: str | None) -> str | None:
+            if e is None:
+                return None
+            m = {
+                "JSON_IETF": "json_ietf",
+                "JSON": "json",
+                "ASCII": "ascii",
+            }
+            return m.get(e, m.get(e.upper(), e.lower()))
+
+        with gNMIclient(**params) as client:  # type: ignore[arg-type]
+            resp: Dict[str, Any] = client.capabilities() or {}
+            # Expected keys in pygnmi response
+            for m in resp.get("supported_models", []) or []:
+                models.append(
+                    ModelIdentifier(
+                        name=m.get("name", ""),
+                        version=m.get("version"),
+                        organization=m.get("organization"),
+                    )
+                )
+            for e in resp.get("supported_encodings", []) or []:
+                ne = normalize_encoding(e)
+                if ne:
+                    encodings.append(ne)
+            gnmi_version = resp.get("gNMI_version")
+
+        return DeviceCapabilities(
+            models=models, encodings=encodings, gnmi_version=gnmi_version
+        )

--- a/src/gnmi/capabilities/version.py
+++ b/src/gnmi/capabilities/version.py
@@ -9,7 +9,7 @@ If parsing fails for both sides, comparisons return None.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple
 import re
 
 

--- a/src/gnmi/capabilities/version.py
+++ b/src/gnmi/capabilities/version.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Version normalization and comparison utilities.
+
+Provides a small NormalizedVersion class that can parse common version
+formats and supports comparisons. Comparison precedence:
+  semantic versions (highest fidelity) > date-like > raw lexicographic.
+If parsing fails for both sides, comparisons return None.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, cast
+import re
+
+
+SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+DATE_RE = re.compile(r"^(\d{4})[-/](\d{2})[-/](\d{2})$")
+
+
+@dataclass(frozen=True)
+class NormalizedVersion:
+    """Normalized representation of a version string.
+
+    Attributes:
+        raw: original string
+        kind: one of 'semver', 'date', or 'raw'
+        parts_int: parsed tuple for semver/date, else None
+        part_raw: raw string for 'raw' kind, else None
+    """
+
+    raw: str
+    kind: str
+    parts_int: Optional[Tuple[int, ...]]
+    part_raw: Optional[str]
+
+    def __lt__(self, other: "NormalizedVersion") -> bool:
+        self._ensure_comparable(other)
+        if self.kind in ("semver", "date"):
+            assert self.parts_int is not None and other.parts_int is not None
+            return self.parts_int < other.parts_int
+        # raw
+        assert self.part_raw is not None and other.part_raw is not None
+        return self.part_raw < other.part_raw
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NormalizedVersion):
+            return False
+        if self.kind != other.kind:
+            return False
+        if self.kind in ("semver", "date"):
+            return self.parts_int == other.parts_int
+        return self.part_raw == other.part_raw
+
+    def _ensure_comparable(self, other: "NormalizedVersion") -> None:
+        if self.kind != other.kind:
+            # Different kinds shouldn't be directly compared
+            raise TypeError("Cannot compare versions of different kinds")
+
+    @staticmethod
+    def from_string(s: str) -> "NormalizedVersion":
+        s = s.strip()
+        m = SEMVER_RE.match(s)
+        if m:
+            major, minor, patch = map(int, m.groups())
+            return NormalizedVersion(
+                raw=s,
+                kind="semver",
+                parts_int=(major, minor, patch),
+                part_raw=None,
+            )
+        m = DATE_RE.match(s)
+        if m:
+            year, month, day = map(int, m.groups())
+            return NormalizedVersion(
+                raw=s, kind="date", parts_int=(year, month, day), part_raw=None
+            )
+        # fallback to raw lexicographic
+        return NormalizedVersion(raw=s, kind="raw", parts_int=None, part_raw=s)
+
+
+def safe_compare(a: Optional[str], b: Optional[str]) -> Optional[int]:
+    """Safely compare two version strings.
+
+    Returns:
+      -1 if a < b, 0 if a == b, 1 if a > b.
+      None if either is None or if kinds differ making comparison ambiguous.
+
+    Rules:
+      - If both parse as semver, compare numerically
+      - Else if both parse as dates, compare by date
+      - Else if both fall back to raw, compare lexicographically
+      - If kinds differ, return None
+    """
+    if a is None or b is None:
+        return None
+
+    va = NormalizedVersion.from_string(a)
+    vb = NormalizedVersion.from_string(b)
+
+    if va.kind != vb.kind:
+        return None
+
+    if va.kind in ("semver", "date"):
+        assert va.parts_int is not None and vb.parts_int is not None
+        if va.parts_int < vb.parts_int:
+            return -1
+        if va.parts_int > vb.parts_int:
+            return 1
+    else:
+        assert va.part_raw is not None and vb.part_raw is not None
+        if va.part_raw < vb.part_raw:
+            return -1
+        if va.part_raw > vb.part_raw:
+            return 1
+    return 0

--- a/src/gnmi/parameters.py
+++ b/src/gnmi/parameters.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Dict, Any
 
 # Thin import for type hints and inference helper
 from src.gnmi.capabilities.inspector import RequestInspector
+from src.gnmi.capabilities.encoding import GnmiEncoding
 from src.gnmi.capabilities.models import ModelRequirement
 
 
@@ -24,13 +25,13 @@ class GnmiRequest:
     Attributes:
         path: List of gNMI path strings to retrieve
         prefix: Prefix for the gNMI request (optional)
-        encoding: Encoding type for the request (defaults to "json_ietf")
+        encoding: Encoding type for the request (GnmiEncoding; defaults to JSON_IETF)
         datatype: Data type to retrieve (defaults to "all")
     """
 
     path: List[str]
     prefix: Optional[str] = None
-    encoding: str = "json_ietf"
+    encoding: GnmiEncoding = GnmiEncoding.JSON_IETF
     datatype: str = "all"
 
     def _as_dict(self) -> Dict[str, Any]:

--- a/src/gnmi/parameters.py
+++ b/src/gnmi/parameters.py
@@ -7,6 +7,10 @@ Provides structured objects for representing gNMI request parameters.
 from dataclasses import dataclass, asdict
 from typing import List, Optional, Dict, Any
 
+# Thin import for type hints and inference helper
+from src.gnmi.capabilities.inspector import RequestInspector
+from src.gnmi.capabilities.models import ModelRequirement
+
 
 @dataclass
 class GnmiRequest:
@@ -40,3 +44,8 @@ class GnmiRequest:
     def __getitem__(self, key):
         """Return item for mapping interface (enables ** unpacking)."""
         return self._as_dict()[key]
+
+    def infer_models(self) -> List[ModelRequirement]:
+        """Infer required models from request paths using RequestInspector."""
+        inspector = RequestInspector()
+        return inspector.infer_requirements(self.path)

--- a/src/gnmi/preflight.py
+++ b/src/gnmi/preflight.py
@@ -60,9 +60,8 @@ def preflight_error_details(
 def compute_effective_encoding(
     result: CapabilityCheckResult, request: GnmiRequest
 ) -> str:
-    """Choose the encoding for this call without mutating the original request."""
-    return (
-        result.selected_encoding
-        if result.selected_encoding
-        else request.encoding
-    )
+    """Choose encoding as canonical string for this call without mutating the request."""
+    if result.selected_encoding:
+        return result.selected_encoding
+    # request.encoding is GnmiEncoding; rely on Enum.__str__ for canonical value
+    return str(getattr(request, "encoding", ""))

--- a/src/gnmi/preflight.py
+++ b/src/gnmi/preflight.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""gNMI preflight helper: checks device capabilities and selects encoding.
+
+Centralizes the orchestration of capability cache lookup/fetch and request
+validation so the client remains small and focused.
+"""
+from __future__ import annotations
+
+
+from src.schemas.models import Device
+from src.gnmi.parameters import GnmiRequest
+from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
+from src.gnmi.capabilities.service import CapabilityService
+from src.gnmi.capabilities.encoding import EncodingPolicy
+from src.gnmi.capabilities.checker import (
+    CapabilityChecker,
+    CapabilityCheckResult,
+)
+from src.gnmi.capabilities.version import safe_compare
+from src.gnmi.capabilities.errors import CapabilityError
+
+
+def perform_preflight(
+    device: Device, request: GnmiRequest
+) -> CapabilityCheckResult:
+    """Validate request against device capabilities using cached data.
+
+    Fetches capabilities on-demand for the specific device if not already
+    cached, then validates required models and encoding. Returns the detailed
+    CapabilityCheckResult with selected_encoding and warnings.
+    """
+    repo = DeviceCapabilitiesRepository()
+    caps = repo.get(device)
+    if caps is None:
+        caps = CapabilityService(repo).get_or_fetch(device)
+
+    checker = CapabilityChecker(
+        service=CapabilityService(repo),
+        version_cmp=safe_compare,
+        encoding_policy=EncodingPolicy(),
+    )
+    return checker.check_with_caps(
+        caps, request.path, getattr(request, "encoding", None)
+    )
+
+
+def preflight_error_details(
+    result: CapabilityCheckResult,
+) -> tuple[str, str]:
+    """Return a normalized (error_type, message) tuple for failed preflight.
+
+    Keeps ErrorResponse creation in the client while centralizing defaulting
+    and extraction logic here for readability.
+    """
+    err_type = result.error_type or CapabilityError.MODEL_NOT_SUPPORTED.value
+    err_msg = result.error_message or "Preflight failed"
+    return err_type, err_msg
+
+
+def compute_effective_encoding(
+    result: CapabilityCheckResult, request: GnmiRequest
+) -> str:
+    """Choose the encoding for this call without mutating the original request."""
+    return (
+        result.selected_encoding
+        if result.selected_encoding
+        else request.encoding
+    )

--- a/src/schemas/responses.py
+++ b/src/schemas/responses.py
@@ -9,6 +9,7 @@ the gNMIBuddy application for representing operation results.
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Dict, Any, Optional, Union
+from .models import NetworkOS
 
 
 class RoutingProtocol(Enum):
@@ -130,7 +131,7 @@ class NetworkOperationResult:
 
     device_name: str
     ip_address: str
-    nos: str
+    nos: NetworkOS
     operation_type: str
     status: OperationStatus
     data: Dict[str, Any] = field(default_factory=dict)

--- a/tests/cmd/commands/device/test_capabilities_command.py
+++ b/tests/cmd/commands/device/test_capabilities_command.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import types
+from click.testing import CliRunner
+from src.cmd.parser import cli, register_commands
+
+
+def test_device_capabilities_help():
+    register_commands()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["device", "capabilities", "--help"])
+    assert result.exit_code == 0
+    assert "capabilities" in result.output.lower()

--- a/tests/collectors/mpls/test_mpls_info.py
+++ b/tests/collectors/mpls/test_mpls_info.py
@@ -22,6 +22,7 @@ from src.schemas.responses import (
     SuccessResponse,
 )
 from src.schemas.models import Device
+from src.schemas.models import NetworkOS
 
 
 class TestMplsInfoFunctions:
@@ -38,8 +39,6 @@ class TestMplsInfoFunctions:
             "openconfig-network-instance:network-instances/network-instance[name=*]/mpls"
             in request.path[0]
         )
-        assert request.encoding == "json_ietf"
-        assert request.datatype == "all"
 
     @patch("src.collectors.mpls.get_gnmi_data")
     def test_get_mpls_information_success(self, mock_get_gnmi_data):
@@ -48,7 +47,7 @@ class TestMplsInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -124,7 +123,7 @@ class TestMplsInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -153,7 +152,7 @@ class TestMplsInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )

--- a/tests/collectors/routing/test_routing_info.py
+++ b/tests/collectors/routing/test_routing_info.py
@@ -27,7 +27,8 @@ from src.schemas.responses import (
     ErrorResponse,
     SuccessResponse,
 )
-from src.schemas.models import Device
+from src.schemas.models import Device, NetworkOS
+from src.gnmi.capabilities.encoding import GnmiEncoding
 
 
 class TestRoutingInfoFunctions:
@@ -44,7 +45,7 @@ class TestRoutingInfoFunctions:
             "openconfig-network-instance:network-instances/network-instance[name=*]/protocols/protocol/bgp"
             in request.path[0]
         )
-        assert request.encoding == "json_ietf"
+        assert request.encoding == GnmiEncoding.JSON_IETF
         assert request.datatype == "all"
 
     def test_isis_request(self):
@@ -56,7 +57,7 @@ class TestRoutingInfoFunctions:
         assert len(request.path) == 2
         assert any("interfaces" in path for path in request.path)
         assert any("global" in path for path in request.path)
-        assert request.encoding == "json_ietf"
+        assert request.encoding == GnmiEncoding.JSON_IETF
         assert request.datatype == "all"
 
     @patch("src.collectors.routing._get_bgp_info")
@@ -69,7 +70,7 @@ class TestRoutingInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -78,7 +79,7 @@ class TestRoutingInfoFunctions:
         bgp_response = NetworkOperationResult(
             device_name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             operation_type="routing_info",
             status=OperationStatus.SUCCESS,
             data={
@@ -91,7 +92,7 @@ class TestRoutingInfoFunctions:
         isis_response = NetworkOperationResult(
             device_name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             operation_type="routing_info",
             status=OperationStatus.SUCCESS,
             data={
@@ -136,7 +137,7 @@ class TestRoutingInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -145,7 +146,7 @@ class TestRoutingInfoFunctions:
         bgp_response = NetworkOperationResult(
             device_name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             operation_type="routing_info",
             status=OperationStatus.SUCCESS,
             data={
@@ -185,7 +186,7 @@ class TestRoutingInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -275,7 +276,7 @@ class TestRoutingInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -305,7 +306,7 @@ class TestRoutingInfoFunctions:
         mock_device = Device(
             name="test-device",
             ip_address="192.168.1.1",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )

--- a/tests/gnmi/capabilities/test_checker.py
+++ b/tests/gnmi/capabilities/test_checker.py
@@ -1,0 +1,89 @@
+from src.gnmi.capabilities.checker import CapabilityChecker
+from src.gnmi.capabilities.models import DeviceCapabilities, ModelIdentifier
+from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
+from src.gnmi.capabilities.service import CapabilityService
+from src.gnmi.capabilities.encoding import EncodingPolicy
+from src.schemas.models import Device
+
+
+class FakeService(CapabilityService):
+    def __init__(self, caps):
+        self._caps = caps
+
+    def get_or_fetch(self, device):
+        return self._caps
+
+
+def _cmp(a, b):
+    if a is None or b is None:
+        return None
+    at = tuple(int(x) for x in a.split("."))
+    bt = tuple(int(x) for x in b.split("."))
+    return -1 if at < bt else (1 if at > bt else 0)
+
+
+def test_checker_missing_model():
+    caps = DeviceCapabilities(
+        models=[ModelIdentifier("openconfig-system", "0.17.1")],
+        encodings=["json_ietf"],
+    )
+    service = FakeService(caps)
+    checker = CapabilityChecker(service, _cmp, EncodingPolicy())
+    device = Device(name="R1", ip_address="1.1.1.1")
+
+    result = checker.check(
+        device, ["openconfig-interfaces:interfaces"], "json_ietf"
+    )
+    assert result.is_failure() and result.error_type == "MODEL_NOT_SUPPORTED"
+
+
+def test_checker_older_model_warning_and_success():
+    caps = DeviceCapabilities(
+        models=[
+            ModelIdentifier("openconfig-system", "0.17.0"),
+            ModelIdentifier("openconfig-interfaces", "4.1.0"),
+        ],
+        encodings=["json"],
+    )
+    service = FakeService(caps)
+    checker = CapabilityChecker(service, _cmp, EncodingPolicy())
+    device = Device(name="R1", ip_address="1.1.1.1")
+
+    result = checker.check(
+        device,
+        [
+            "openconfig-system:/system",
+            "openconfig-interfaces:interfaces",
+        ],
+        "json",
+    )
+    assert result.success is True and result.selected_encoding == "json"
+    assert any("older" in w for w in result.warnings)
+
+
+def test_checker_encoding_not_supported():
+    caps = DeviceCapabilities(
+        models=[ModelIdentifier("openconfig-system", "0.17.1")],
+        encodings=["json"],
+    )
+    service = FakeService(caps)
+    checker = CapabilityChecker(service, _cmp, EncodingPolicy())
+    device = Device(name="R1", ip_address="1.1.1.1")
+
+    result = checker.check(device, ["openconfig-system:/system"], "json_ietf")
+    assert (
+        result.is_failure() and result.error_type == "ENCODING_NOT_SUPPORTED"
+    )
+
+
+def test_checker_fallback_encoding():
+    caps = DeviceCapabilities(
+        models=[ModelIdentifier("openconfig-system", "0.17.1")],
+        encodings=["ASCII"],
+    )
+    service = FakeService(caps)
+    checker = CapabilityChecker(service, _cmp, EncodingPolicy())
+    device = Device(name="R1", ip_address="1.1.1.1")
+
+    result = checker.check(device, ["openconfig-system:/system"], "json_ietf")
+    assert result.success is True and result.selected_encoding == "ascii"

--- a/tests/gnmi/capabilities/test_encoding.py
+++ b/tests/gnmi/capabilities/test_encoding.py
@@ -1,17 +1,17 @@
-from src.gnmi.capabilities.encoding import EncodingPolicy
+from src.gnmi.capabilities.encoding import EncodingPolicy, GnmiEncoding
 
 
 def test_normalize_and_choose_supported():
     p = EncodingPolicy()
-    assert p.normalize("JSON_IETF") == "json_ietf"
-    assert p.normalize("json") == "json"
+    assert p.normalize("JSON_IETF") == GnmiEncoding.JSON_IETF
+    assert p.normalize("json") == GnmiEncoding.JSON
 
     supported = ["JSON_IETF", "JSON"]
     sel, fb = p.choose_supported("json_ietf", supported)
-    assert sel == "json_ietf" and fb is False
+    assert sel == GnmiEncoding.JSON_IETF and fb is False
 
     sel, fb = p.choose_supported("ascii", supported)
     assert sel is None and fb is False
 
     sel, fb = p.choose_supported("json_ietf", ["ASCII"])  # fallback
-    assert sel == "ascii" and fb is True
+    assert sel == GnmiEncoding.ASCII and fb is True

--- a/tests/gnmi/capabilities/test_encoding.py
+++ b/tests/gnmi/capabilities/test_encoding.py
@@ -1,0 +1,17 @@
+from src.gnmi.capabilities.encoding import EncodingPolicy
+
+
+def test_normalize_and_choose_supported():
+    p = EncodingPolicy()
+    assert p.normalize("JSON_IETF") == "json_ietf"
+    assert p.normalize("json") == "json"
+
+    supported = ["JSON_IETF", "JSON"]
+    sel, fb = p.choose_supported("json_ietf", supported)
+    assert sel == "json_ietf" and fb is False
+
+    sel, fb = p.choose_supported("ascii", supported)
+    assert sel is None and fb is False
+
+    sel, fb = p.choose_supported("json_ietf", ["ASCII"])  # fallback
+    assert sel == "ascii" and fb is True

--- a/tests/gnmi/capabilities/test_inspector.py
+++ b/tests/gnmi/capabilities/test_inspector.py
@@ -1,0 +1,24 @@
+from src.gnmi.capabilities.inspector import RequestInspector
+
+
+def test_infer_requirements_basic_and_variants():
+    inspector = RequestInspector()
+    paths = [
+        "openconfig-system:/system",
+        "openconfig-interfaces:interfaces/interface[name=*]/state",
+        "openconfig-network-instance:network-instances/network-instance[name=default]",
+        "openconfig-system:system",
+    ]
+    reqs = inspector.infer_requirements(paths)
+    names = sorted([r.name for r in reqs])
+    assert names == [
+        "openconfig-interfaces",
+        "openconfig-network-instance",
+        "openconfig-system",
+    ]
+
+
+def test_infer_requirements_ignores_unknown():
+    inspector = RequestInspector()
+    reqs = inspector.infer_requirements(["unknown:/x", "something-other/y"])
+    assert reqs == []

--- a/tests/gnmi/capabilities/test_models.py
+++ b/tests/gnmi/capabilities/test_models.py
@@ -4,6 +4,7 @@ from src.gnmi.capabilities.models import (
     ModelRequirement,
     DeviceCapabilities,
 )
+from src.gnmi.capabilities.encoding import GnmiEncoding
 
 
 def test_model_identifier_basic():
@@ -41,7 +42,7 @@ def test_device_capabilities_methods():
             ModelIdentifier(name="openconfig-system", version="0.17.0"),
             ModelIdentifier(name="openconfig-interfaces", version="4.1.0"),
         ],
-        encodings=["JSON_IETF", "JSON"],
+        encodings=[GnmiEncoding.JSON_IETF, GnmiEncoding.JSON],
         gnmi_version="0.8.0",
     )
 
@@ -52,6 +53,6 @@ def test_device_capabilities_methods():
     present, older = caps.has_model(req_int, _cmp)
     assert present is True and older is False
 
-    assert caps.supports_encoding("json_ietf", _norm)
-    assert caps.supports_encoding("json", _norm)
-    assert not caps.supports_encoding("ascii", _norm)
+    assert caps.supports_encoding(GnmiEncoding.JSON_IETF)
+    assert caps.supports_encoding(GnmiEncoding.JSON)
+    assert not caps.supports_encoding(GnmiEncoding.ASCII)

--- a/tests/gnmi/capabilities/test_models.py
+++ b/tests/gnmi/capabilities/test_models.py
@@ -1,0 +1,57 @@
+import pytest
+from src.gnmi.capabilities.models import (
+    ModelIdentifier,
+    ModelRequirement,
+    DeviceCapabilities,
+)
+
+
+def test_model_identifier_basic():
+    m = ModelIdentifier(
+        name="openconfig-system", version="0.17.1", organization="OC"
+    )
+    assert m.matches("openconfig-system")
+    assert m.normalized_version() == "0.17.1"
+    assert "openconfig-system@0.17.1" in str(m)
+
+
+def test_model_requirement_requires_version():
+    r1 = ModelRequirement(name="openconfig-system", minimum_version="0.17.1")
+    r2 = ModelRequirement(name="openconfig-system")
+    assert r1.requires_version() is True
+    assert r2.requires_version() is False
+
+
+def _cmp(a, b):
+    if a is None or b is None:
+        return None
+    # very small comparator for tests: numeric compare by tuple of ints
+    at = tuple(int(x) for x in a.split("."))
+    bt = tuple(int(x) for x in b.split("."))
+    return -1 if at < bt else (1 if at > bt else 0)
+
+
+def _norm(x):
+    return x.lower() if x else None
+
+
+def test_device_capabilities_methods():
+    caps = DeviceCapabilities(
+        models=[
+            ModelIdentifier(name="openconfig-system", version="0.17.0"),
+            ModelIdentifier(name="openconfig-interfaces", version="4.1.0"),
+        ],
+        encodings=["JSON_IETF", "JSON"],
+        gnmi_version="0.8.0",
+    )
+
+    req_sys = ModelRequirement("openconfig-system", "0.17.1")
+    req_int = ModelRequirement("openconfig-interfaces", "4.0.0")
+    present, older = caps.has_model(req_sys, _cmp)
+    assert present is True and older is True
+    present, older = caps.has_model(req_int, _cmp)
+    assert present is True and older is False
+
+    assert caps.supports_encoding("json_ietf", _norm)
+    assert caps.supports_encoding("json", _norm)
+    assert not caps.supports_encoding("ascii", _norm)

--- a/tests/gnmi/capabilities/test_models.py
+++ b/tests/gnmi/capabilities/test_models.py
@@ -46,7 +46,7 @@ def test_device_capabilities_methods():
     )
 
     req_sys = ModelRequirement("openconfig-system", "0.17.1")
-    req_int = ModelRequirement("openconfig-interfaces", "4.0.0")
+    req_int = ModelRequirement("openconfig-interfaces", "3.0.0")
     present, older = caps.has_model(req_sys, _cmp)
     assert present is True and older is True
     present, older = caps.has_model(req_int, _cmp)

--- a/tests/gnmi/capabilities/test_repository.py
+++ b/tests/gnmi/capabilities/test_repository.py
@@ -1,0 +1,24 @@
+from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
+from src.gnmi.capabilities.models import DeviceCapabilities, ModelIdentifier
+from src.schemas.models import Device
+
+
+def _dev(name="R1"):
+    return Device(name=name, ip_address="10.0.0.1", port=57777)
+
+
+def test_repo_keying_and_basic_ops():
+    repo = DeviceCapabilitiesRepository()
+    d = _dev()
+    key = repo.make_key(d)
+    assert key.endswith(":10.0.0.1:57777")
+
+    assert repo.get(d) is None and repo.has(d) is False
+    caps = DeviceCapabilities(
+        models=[ModelIdentifier("openconfig-system")], encodings=["json"]
+    )
+    repo.set(d, caps)
+    assert repo.has(d) is True and repo.get(d) == caps
+
+    repo.clear()
+    assert repo.get(d) is None

--- a/tests/gnmi/capabilities/test_version.py
+++ b/tests/gnmi/capabilities/test_version.py
@@ -1,0 +1,20 @@
+from src.gnmi.capabilities.version import NormalizedVersion, safe_compare
+
+
+def test_semver_parse_and_compare():
+    a = NormalizedVersion.from_string("1.2.3")
+    b = NormalizedVersion.from_string("1.3.0")
+    assert a.kind == "semver" and b.kind == "semver"
+    assert safe_compare("1.2.3", "1.3.0") == -1
+    assert safe_compare("1.3.0", "1.3.0") == 0
+    assert safe_compare("1.4.0", "1.3.0") == 1
+
+
+def test_date_and_raw_comparisons():
+    assert safe_compare("2024-12-01", "2025-01-01") == -1
+    assert safe_compare("abc", "abd") == -1
+
+
+def test_mixed_kinds_return_none():
+    assert safe_compare("1.2.3", "20240101") is None
+    assert safe_compare("1.2.3", None) is None

--- a/tests/gnmi/test_parameters.py
+++ b/tests/gnmi/test_parameters.py
@@ -6,7 +6,6 @@ Tests the contract for parameter objects used in GNMI requests.
 
 import os
 import sys
-import pytest
 
 # Add the project root to the Python path
 sys.path.insert(
@@ -14,6 +13,7 @@ sys.path.insert(
 )
 
 from src.gnmi.parameters import GnmiRequest
+from src.gnmi.capabilities.encoding import GnmiEncoding
 
 
 class TestGnmiRequest:
@@ -25,19 +25,19 @@ class TestGnmiRequest:
         request = GnmiRequest(path=["/interfaces"])
         assert request.path == ["/interfaces"]
         assert request.prefix is None
-        assert request.encoding == "json_ietf"
+        assert request.encoding == GnmiEncoding.JSON_IETF
         assert request.datatype == "all"
 
         # Test with all core parameters plus some gNMI specific ones
         request = GnmiRequest(
             path=["/interfaces", "/network-instances"],
             prefix="/openconfig",
-            encoding="json",
+            encoding=GnmiEncoding.JSON,
             datatype="config",
         )
         assert request.path == ["/interfaces", "/network-instances"]
         assert request.prefix == "/openconfig"
-        assert request.encoding == "json"
+        assert request.encoding == GnmiEncoding.JSON
         assert request.datatype == "config"
 
     def test_mapping_functionality(self):
@@ -45,7 +45,7 @@ class TestGnmiRequest:
         # Test minimal parameters
         request = GnmiRequest(path=["/interfaces"])
         assert request["path"] == ["/interfaces"]
-        assert request["encoding"] == "json_ietf"
+        assert request["encoding"] == GnmiEncoding.JSON_IETF
         assert request["datatype"] == "all"
         # prefix is included even when None (simplified behavior)
         assert request["prefix"] is None
@@ -54,12 +54,12 @@ class TestGnmiRequest:
         request = GnmiRequest(
             path=["/interfaces", "/network-instances"],
             prefix="/openconfig",
-            encoding="json",
+            encoding=GnmiEncoding.JSON,
             datatype="config",
         )
         assert request["path"] == ["/interfaces", "/network-instances"]
         assert request["prefix"] == "/openconfig"
-        assert request["encoding"] == "json"
+        assert request["encoding"] == GnmiEncoding.JSON
         assert request["datatype"] == "config"
 
         # Test that it can be unpacked with **

--- a/tests/schemas/test_responses.py
+++ b/tests/schemas/test_responses.py
@@ -17,6 +17,7 @@ from src.schemas.responses import (
     NetworkOperationResult,
 )
 from src.schemas.models import Device
+from src.schemas.responses import NetworkOS
 
 
 class TestOperationStatus:
@@ -286,7 +287,7 @@ class TestNetworkOperationResult:
 
         assert type_hints["device_name"] == str
         assert type_hints["ip_address"] == str
-        assert type_hints["nos"] == str
+        assert type_hints["nos"] == NetworkOS
         assert type_hints["operation_type"] == str
         assert type_hints["status"] == OperationStatus
 


### PR DESCRIPTION
Adds a `device capabilities` command, capability caching, and preflight validation for required OpenConfig models and encodings.

Closes #14