### PR TITLE
Fix: NetworkOperationResult validation error - Replace "N/A" with NetworkOS.UNKNOWN

### DIFF
--- a/src/cmd/batch.py
+++ b/src/cmd/batch.py
@@ -13,6 +13,7 @@ from src.schemas.responses import (
     ErrorResponse,
 )
 from src.logging import get_logger
+from src.schemas.models import NetworkOS
 from src.inventory.manager import InventoryManager
 
 logger = get_logger(__name__)
@@ -229,7 +230,7 @@ class BatchOperationExecutor:
         return NetworkOperationResult(
             device_name=device_name,
             ip_address="unknown",  # We might not have this info in error cases
-            nos="unknown",
+            nos=NetworkOS.UNKNOWN,
             operation_type=operation_type,
             status=OperationStatus.FAILED,
             data={},

--- a/src/collectors/topology/network_topology.py
+++ b/src/collectors/topology/network_topology.py
@@ -3,6 +3,7 @@ from src.schemas.responses import (
     OperationStatus,
     NetworkOperationResult,
 )
+from src.schemas.models import NetworkOS
 from .utils import _build_graph_ip_only
 from src.logging import get_logger, log_operation
 
@@ -38,7 +39,7 @@ def get_network_topology() -> NetworkOperationResult:
             return NetworkOperationResult(
                 device_name="ALL_DEVICES",
                 ip_address="0.0.0.0",
-                nos="N/A",
+                nos=NetworkOS.UNKNOWN,
                 operation_type="network_topology",
                 status=OperationStatus.FAILED,
                 data={},
@@ -56,7 +57,7 @@ def get_network_topology() -> NetworkOperationResult:
             return NetworkOperationResult(
                 device_name="ALL_DEVICES",
                 ip_address="0.0.0.0",
-                nos="N/A",
+                nos=NetworkOS.UNKNOWN,
                 operation_type="network_topology",
                 status=OperationStatus.FAILED,
                 data={},
@@ -110,7 +111,7 @@ def get_network_topology() -> NetworkOperationResult:
         return NetworkOperationResult(
             device_name="ALL_DEVICES",
             ip_address="0.0.0.0",
-            nos="N/A",
+            nos=NetworkOS.UNKNOWN,
             operation_type="network_topology",
             status=OperationStatus.SUCCESS,
             data={"direct_connections": direct_connections},
@@ -134,7 +135,7 @@ def get_network_topology() -> NetworkOperationResult:
         return NetworkOperationResult(
             device_name="ALL_DEVICES",
             ip_address="0.0.0.0",
-            nos="N/A",
+            nos=NetworkOS.UNKNOWN,
             operation_type="network_topology",
             status=OperationStatus.FAILED,
             data={},


### PR DESCRIPTION
## Problem

The MCP tool `get_network_topology_api` was failing with a Pydantic validation error:

```
Error executing tool get_network_topology_api: 1 validation error for NetworkOperationResult
nos
  Input should be 'iosxr' or 'unknown' [type=enum, input_value='N/A', input_type=str]
```

## Root Cause

The `get_network_topology()` function in `/src/collectors/topology/network_topology.py` was setting `nos="N/A"` in NetworkOperationResult objects, but the schema expects a `NetworkOS` enum value (either 'iosxr' or 'unknown').

## Solution

1. **Added missing import**: Added `from src.schemas.models import NetworkOS` to the imports
2. **Fixed enum usage**: Replaced all instances of `nos="N/A"` with `nos=NetworkOS.UNKNOWN`

## Changes

- Fixed 4 instances of invalid enum usage in `src/collectors/topology/network_topology.py`
- Added proper import for `NetworkOS` enum

## Validation

✅ Function executes without validation errors  
✅ Returns proper `NetworkOS` enum values  
✅ MCP API function works correctly  
✅ All topology-related tests pass (10/10)  
✅ No remaining "N/A" values found in codebase  

## Test Results

```
Testing get_network_topology_api (MCP function)...
✓ MCP function completed successfully
✓ Result type: NetworkOperationResult
✓ NOS type: NetworkOS
✓ NOS value: unknown
✓ Status: success
✓ Enum validation passed!
```

This fix resolves the MCP validation error and ensures all NetworkOperationResult objects use proper enum values.