### PR TITLE
feat: Add proper IP address typing with ipaddress module

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ See the [API definition](/api.py) for all available APIs and options.
 
 ### Device Compatibility
 
+**Tested on:**
+
+- Cisco XRd Control Plane (`24.4.1.26I`, `25.3.1`)
+
+> [!NOTE]
+> The `get_logs()` function only works on IOS-XR.
+
 Devices **must** support gNMI and OpenConfig models listed below:
 
 **OpenConfig Models dependencies**
@@ -39,14 +46,11 @@ Devices **must** support gNMI and OpenConfig models listed below:
 > [!NOTE]
 > If the required model for a function is not found, gNMIBuddy will return an error. If the model version is older than required, it will continue execution but warn the user about potential errors.
 
-You can use `uv run gnmibuddy.py device capabilities` to verify the supported models on a specific device. See the options available.
+You can use the capabilities command to verify the supported models on a specific device. If you have many devices you can use the `--device` option.
 
-**Tested on:**
-
-- Cisco XRd Control Plane (`24.4.1.26I`)
-
-> [!NOTE]
-> The `get_logs()` function only works on IOS-XR.
+```bash
+uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy device capabilities --all-devices
+```
 
 ### Device Inventory file
 
@@ -299,7 +303,7 @@ Don't have network devices? Use the [DevNet XRd Sandbox](https://devnetsandbox.c
 # If you cloned the repo
 # Enable gRPC on the DevNet XRd Sandbox
 ANSIBLE_HOST_KEY_CHECKING=False \
-uvx --from ansible-core --with "paramiko,ansible" \
+uvx --from "ansible-core==2.19.2" --with "paramiko,ansible" \
 ansible-playbook ansible-helper/xrd_apply_config.yaml -i ansible-helper/hosts
 ```
 
@@ -313,7 +317,7 @@ bash -c 'TMPDIR=$(mktemp -d) \
 && trap "rm -rf $TMPDIR" EXIT \
 && curl -s https://raw.githubusercontent.com/jillesca/gNMIBuddy/refs/heads/main/ansible-helper/xrd_apply_config.yaml > "$TMPDIR/playbook.yaml" \
 && curl -s https://raw.githubusercontent.com/jillesca/gNMIBuddy/refs/heads/main/ansible-helper/hosts > "$TMPDIR/hosts" \
-&& uvx --from ansible-core --with "paramiko,ansible" ansible-playbook "$TMPDIR/playbook.yaml" -i "$TMPDIR/hosts"'
+&& uvx --from "ansible-core==2.19.2" --with "paramiko,ansible" ansible-playbook "$TMPDIR/playbook.yaml" -i "$TMPDIR/hosts"'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -356,8 +356,8 @@ Single device operations return a `NetworkOperationResult` object with detailed 
 @dataclass
 class NetworkOperationResult:
     device_name: str
-    ip_address: str
-    nos: str
+    ip_address: IPAddress
+    nos: NetworkOS
     operation_type: str
     status: OperationStatus
     data: Dict[str, Any] = field(default_factory=dict)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Devices **must** support gNMI and OpenConfig models listed below:
 You can use the capabilities command to verify the supported models on a specific device. If you have many devices you can use the `--device` option.
 
 ```bash
-uvx --from git+https://github.com/jillesca/gNMIBuddy.git gnmibuddy device capabilities --all-devices
+uvx --from git+https://github.com/jillesca/gNMIBuddy.git \
+gnmibuddy device capabilities --all-devices
 ```
 
 ### Device Inventory file

--- a/ansible-helper/hosts
+++ b/ansible-helper/hosts
@@ -16,3 +16,9 @@ ansible_network_os=cisco.iosxr.iosxr
 ansible_iosxr_use_proxy=false
 # Skip platform detection to avoid 'show inventory' command issues with XRd
 ansible_iosxr_platform=iosxr
+# Additional variables to prevent platform detection
+ansible_gather_subset=!all
+ansible_facts_modules=[]
+ansible_iosxr_skip_platform_detection=true
+# Force specific device type
+ansible_device_os=iosxr

--- a/ansible-helper/hosts
+++ b/ansible-helper/hosts
@@ -13,3 +13,6 @@ ansible_user=cisco
 ansible_password=C1sco12345
 ansible_connection=network_cli
 ansible_network_os=cisco.iosxr.iosxr
+ansible_iosxr_use_proxy=false
+# Skip platform detection to avoid 'show inventory' command issues with XRd
+ansible_iosxr_platform=iosxr

--- a/ansible-helper/xrd_apply_config.yaml
+++ b/ansible-helper/xrd_apply_config.yaml
@@ -11,9 +11,12 @@
       cisco.iosxr.iosxr_config:
         lines:
           - grpc
+        backup: no
+
     - name: Configure gRPC parameters
       cisco.iosxr.iosxr_config:
         lines:
           - port 57777
           - no-tls
         parents: grpc
+        backup: no

--- a/ansible-helper/xrd_apply_config.yaml
+++ b/ansible-helper/xrd_apply_config.yaml
@@ -5,6 +5,9 @@
 
   vars:
     ansible_command_timeout: 60
+    # Disable platform detection to avoid 'show inventory' command
+    ansible_network_os: cisco.iosxr.iosxr
+    ansible_iosxr_use_proxy: false
 
   tasks:
     - name: Enable gRPC

--- a/ansible-helper/xrd_apply_config.yaml
+++ b/ansible-helper/xrd_apply_config.yaml
@@ -8,6 +8,11 @@
     # Disable platform detection to avoid 'show inventory' command
     ansible_network_os: cisco.iosxr.iosxr
     ansible_iosxr_use_proxy: false
+    # Force disable facts gathering and platform detection
+    ansible_gather_subset: "!all"
+    ansible_facts_modules: []
+    # Skip device platform detection entirely
+    ansible_iosxr_skip_platform_detection: true
 
   tasks:
     - name: Enable gRPC

--- a/src/gnmi/capabilities/service.py
+++ b/src/gnmi/capabilities/service.py
@@ -27,7 +27,7 @@ class CapabilityService:
     def _fetch(self, device: Device) -> DeviceCapabilities:
         # Build connection params locally to avoid circular import with gnmi.client
         params = {
-            "target": (str(device.ip_address), device.port),
+            "target": (device.host, device.port),
             "username": device.username,
             "password": device.password,
             "insecure": device.insecure,

--- a/src/gnmi/capabilities/service.py
+++ b/src/gnmi/capabilities/service.py
@@ -27,7 +27,7 @@ class CapabilityService:
     def _fetch(self, device: Device) -> DeviceCapabilities:
         # Build connection params locally to avoid circular import with gnmi.client
         params = {
-            "target": (device.ip_address, device.port),
+            "target": (str(device.ip_address), device.port),
             "username": device.username,
             "password": device.password,
             "insecure": device.insecure,

--- a/src/gnmi/client.py
+++ b/src/gnmi/client.py
@@ -60,12 +60,12 @@ class GnmiConnectionManager:
         logger.debug(
             "Creating gNMI connection params for device %s (%s:%d)",
             device.name,
-            device.ip_address,
+            device.host,
             device.port,
         )
 
         params = {
-            "target": (str(device.ip_address), device.port),
+            "target": (device.host, device.port),
             "username": device.username,
             "password": device.password,
             "insecure": device.insecure,
@@ -383,7 +383,7 @@ if __name__ == "__main__":
         logger.info(
             "Testing with device: %s (%s:%d)",
             device.name,
-            device.ip_address,
+            device.host,
             device.port,
         )
 

--- a/src/gnmi/client.py
+++ b/src/gnmi/client.py
@@ -65,7 +65,7 @@ class GnmiConnectionManager:
         )
 
         params = {
-            "target": (device.ip_address, device.port),
+            "target": (str(device.ip_address), device.port),
             "username": device.username,
             "password": device.password,
             "insecure": device.insecure,
@@ -388,12 +388,14 @@ if __name__ == "__main__":
         )
 
         # Creating a GnmiRequest for an example query
+        from src.gnmi.capabilities.encoding import GnmiEncoding
+
         request = GnmiRequest(
             path=[
                 "openconfig-interfaces:interfaces/interface[name=*]/state/admin-status",
                 "openconfig-interfaces:interfaces/interface[name=*]/state/oper-status",
             ],
-            encoding="json_ietf",
+            encoding=GnmiEncoding.JSON_IETF,
         )
 
         logger.info("Executing gNMI request...")

--- a/src/inventory/file_handler.py
+++ b/src/inventory/file_handler.py
@@ -4,9 +4,9 @@ File handling module for inventory.
 Handles parsing JSON inventory files and related file operations.
 """
 
+import ipaddress
 import json
 import os
-import sys
 from typing import Dict, List, Any, Optional, cast
 from pathlib import Path
 
@@ -132,16 +132,17 @@ def _convert_device_data(device_data: DeviceData) -> DeviceData:
     """
     Convert device data from JSON format to Device-compatible format.
 
-    Handles conversion of string 'nos' field to NetworkOS enum.
+    Handles conversion of string 'nos' field to NetworkOS enum and
+    string 'ip_address' field to ipaddress object.
 
     Args:
         device_data: Raw device data from JSON
 
     Returns:
-        Device data with enum conversions applied
+        Device data with enum and ipaddress conversions applied
 
     Raises:
-        ValueError: If nos value is not supported
+        ValueError: If nos value is not supported or ip_address is invalid
     """
     converted_data = device_data.copy()
 
@@ -155,6 +156,29 @@ def _convert_device_data(device_data: DeviceData) -> DeviceData:
             error_msg = f"Invalid network OS '{nos_value}'. Must be one of: {valid_values}"
             logger.error(error_msg)
             raise ValueError(error_msg) from e
+
+    # Convert ip_address string to ipaddress object if present
+    if "ip_address" in converted_data and isinstance(
+        converted_data["ip_address"], str
+    ):
+        ip_str = converted_data["ip_address"]
+        if ip_str.strip():  # Only convert non-empty strings
+            try:
+                converted_data["ip_address"] = ipaddress.ip_address(ip_str)
+                logger.debug(
+                    "Converted IP address '%s' to %s object",
+                    ip_str,
+                    type(converted_data["ip_address"]).__name__,
+                )
+            except (ipaddress.AddressValueError, ValueError) as e:
+                error_msg = f"Invalid IP address '{ip_str}': {e}"
+                logger.error(error_msg)
+                raise ValueError(error_msg) from e
+        else:
+            # Empty IP address is not allowed
+            error_msg = "IP address cannot be empty"
+            logger.error(error_msg)
+            raise ValueError(error_msg)
 
     return converted_data
 

--- a/src/inventory/validator.py
+++ b/src/inventory/validator.py
@@ -887,6 +887,19 @@ class InventoryValidator:
             nos_value = converted_data["nos"]
             converted_data["nos"] = NetworkOS(nos_value)
 
+        # Convert ip_address string to ipaddress object if present
+        if "ip_address" in converted_data and isinstance(
+            converted_data["ip_address"], str
+        ):
+            ip_str = converted_data["ip_address"]
+            if ip_str.strip():  # Only convert non-empty strings
+                try:
+                    converted_data["ip_address"] = ip_address(ip_str)
+                except (AddressValueError, ValueError):
+                    # Leave as string - the validation will catch this error
+                    # and provide appropriate error messages
+                    pass
+
         return converted_data
 
     def _create_result(

--- a/src/schemas/models.py
+++ b/src/schemas/models.py
@@ -97,3 +97,8 @@ class Device:
     grpc_options: Optional[list] = None
     show_diff: Optional[str] = None
     insecure: bool = True
+
+    @property
+    def host(self) -> str:
+        """Return string representation of the IP address for network connections."""
+        return str(self.ip_address)

--- a/src/schemas/models.py
+++ b/src/schemas/models.py
@@ -47,7 +47,7 @@ class DeviceErrorResult:
     """Result class for device error conditions."""
 
     msg: str
-    nos: str = "unknown"
+    nos: NetworkOS = NetworkOS.UNKNOWN
     ip_address: IPAddress = None
     device_info: Optional[Dict[str, Any]] = None
 

--- a/src/schemas/models.py
+++ b/src/schemas/models.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict, Any, Union
 
 
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address, None]
+
+
 class NetworkOS(Enum):
     """Supported Network Operating Systems"""
 
@@ -55,8 +58,9 @@ class Device:
     Device representation with all attributes from src.inventory.
 
     Attributes:
-        name: Device hostname or identifier
-        ip_address: IP address for device management
+        name: Device hostname or identifier (required)
+        ip_address: IP address for device management (required)
+        nos: Network Operating System identifier
         port: Port number for device connections
         nos: Network Operating System identifier
         username: Authentication username (optional, required if not using certificates)
@@ -79,9 +83,7 @@ class Device:
     """
 
     name: str = ""
-    ip_address: Union[ipaddress.IPv4Address, ipaddress.IPv6Address, None] = (
-        None
-    )
+    ip_address: IPAddress = None
     port: int = 830
     nos: NetworkOS = NetworkOS.IOSXR
     username: Optional[str] = None

--- a/src/schemas/models.py
+++ b/src/schemas/models.py
@@ -48,7 +48,7 @@ class DeviceErrorResult:
 
     msg: str
     nos: str = "unknown"
-    ip_address: str = "unknown"
+    ip_address: IPAddress = None
     device_info: Optional[Dict[str, Any]] = None
 
 

--- a/src/schemas/models.py
+++ b/src/schemas/models.py
@@ -6,6 +6,7 @@ Contains data models for representing network devices and related
 inventory structures used throughout the application.
 """
 
+import ipaddress
 from enum import Enum
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any, Union
@@ -78,7 +79,9 @@ class Device:
     """
 
     name: str = ""
-    ip_address: str = ""
+    ip_address: Union[ipaddress.IPv4Address, ipaddress.IPv6Address, None] = (
+        None
+    )
     port: int = 830
     nos: NetworkOS = NetworkOS.IOSXR
     username: Optional[str] = None

--- a/src/schemas/responses.py
+++ b/src/schemas/responses.py
@@ -9,7 +9,7 @@ the gNMIBuddy application for representing operation results.
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Dict, Any, Optional, Union
-from .models import NetworkOS
+from .models import NetworkOS, IPAddress
 
 
 class RoutingProtocol(Enum):
@@ -117,7 +117,6 @@ class SuccessResponse:
         return f"SuccessResponse(data_count={data_count}{timestamp_str})"
 
 
-# Unified response object for all network tools
 @dataclass
 class NetworkOperationResult:
     """
@@ -136,7 +135,7 @@ class NetworkOperationResult:
     """
 
     device_name: str
-    ip_address: str
+    ip_address: IPAddress
     nos: NetworkOS
     operation_type: str
     status: OperationStatus

--- a/src/services/commands.py
+++ b/src/services/commands.py
@@ -95,7 +95,7 @@ def run(
         )
         return NetworkOperationResult(
             device_name=device_name,
-            ip_address="unknown",
+            ip_address=None,
             nos=NetworkOS.UNKNOWN,
             operation_type="device_retrieval",
             status=OperationStatus.FAILED,

--- a/tests/cmd/commands/device/test_list_integration.py
+++ b/tests/cmd/commands/device/test_list_integration.py
@@ -5,9 +5,10 @@ Integration tests for the device list CLI command with sanitization.
 Tests CLI output redaction, class-based data handling, and no sensitive data leakage.
 """
 
+import ipaddress
 import pytest
 import json
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from click.testing import CliRunner
 
 from src.cmd.commands.device.list import device_list
@@ -28,7 +29,7 @@ class TestDeviceListCLIIntegration:
         """Create a mock device with sensitive authentication data."""
         return Device(
             name="test-device-1",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -57,7 +58,7 @@ class TestDeviceListCLIIntegration:
         """Create a mock sanitized device list result."""
         sanitized_device = Device(
             name="test-device-1",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -402,7 +403,7 @@ class TestDeviceListCLIIntegration:
         # Create multiple devices with different sensitive data patterns
         device1 = Device(
             name="device-1",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             username="admin",
             password="secret1",
@@ -411,7 +412,7 @@ class TestDeviceListCLIIntegration:
 
         device2 = Device(
             name="device-2",
-            ip_address="192.168.1.2",
+            ip_address=ipaddress.IPv4Address("192.168.1.2"),
             nos=NetworkOS.IOSXR,
             username="user",
             password=None,  # No password
@@ -421,7 +422,7 @@ class TestDeviceListCLIIntegration:
         # Create sanitized versions
         sanitized_device1 = Device(
             name="device-1",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             username="admin",
             password="***",
@@ -430,7 +431,7 @@ class TestDeviceListCLIIntegration:
 
         sanitized_device2 = Device(
             name="device-2",
-            ip_address="192.168.1.2",
+            ip_address=ipaddress.IPv4Address("192.168.1.2"),
             nos=NetworkOS.IOSXR,
             username="user",
             password=None,

--- a/tests/cmd/test_advanced_features.py
+++ b/tests/cmd/test_advanced_features.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Tests for Phase 4 advanced CLI features"""
 
+import ipaddress
 import pytest
 import json
 import yaml
 import tempfile
 import os
 import sys
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from click.testing import CliRunner
 from src.cmd.formatters import (
     JSONFormatter,
@@ -29,6 +30,7 @@ from src.schemas.responses import (
     OperationStatus,
     ErrorResponse,
 )
+from src.schemas.models import NetworkOS
 from src.cmd.parser import cli
 
 
@@ -273,8 +275,8 @@ class TestBatchOperations:
         """Test NetworkOperationResult dataclass"""
         result = NetworkOperationResult(
             device_name="R1",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             operation_type="interface_info",
             status=OperationStatus.SUCCESS,
             data={"status": "up"},
@@ -282,8 +284,8 @@ class TestBatchOperations:
         )
 
         assert result.device_name == "R1"
-        assert result.ip_address == "192.168.1.1"
-        assert result.nos == "iosxr"
+        assert result.ip_address == ipaddress.IPv4Address("192.168.1.1")
+        assert result.nos == NetworkOS.IOSXR
         assert result.operation_type == "interface_info"
         assert result.status == OperationStatus.SUCCESS
         assert result.data == {"status": "up"}
@@ -311,8 +313,8 @@ class TestBatchOperations:
         results = [
             NetworkOperationResult(
                 device_name="R1",
-                ip_address="192.168.1.1",
-                nos="iosxr",
+                ip_address=ipaddress.IPv4Address("192.168.1.1"),
+                nos=NetworkOS.IOSXR,
                 operation_type="interface_info",
                 status=OperationStatus.SUCCESS,
                 data={"status": "up"},
@@ -320,8 +322,8 @@ class TestBatchOperations:
             ),
             NetworkOperationResult(
                 device_name="R2",
-                ip_address="192.168.1.2",
-                nos="iosxr",
+                ip_address=ipaddress.IPv4Address("192.168.1.2"),
+                nos=NetworkOS.IOSXR,
                 operation_type="interface_info",
                 status=OperationStatus.FAILED,
                 data={},
@@ -332,8 +334,8 @@ class TestBatchOperations:
             ),
             NetworkOperationResult(
                 device_name="R3",
-                ip_address="192.168.1.3",
-                nos="iosxr",
+                ip_address=ipaddress.IPv4Address("192.168.1.3"),
+                nos=NetworkOS.IOSXR,
                 operation_type="interface_info",
                 status=OperationStatus.SUCCESS,
                 data={"status": "up"},
@@ -447,8 +449,8 @@ class TestBatchOperations:
         def mock_operation(device_name):
             return NetworkOperationResult(
                 device_name=device_name,
-                ip_address="192.168.1.1",
-                nos="iosxr",
+                ip_address=ipaddress.IPv4Address("192.168.1.1"),
+                nos=NetworkOS.IOSXR,
                 operation_type="test",
                 status=OperationStatus.SUCCESS,
                 data={"device": device_name, "status": "success"},
@@ -478,8 +480,8 @@ class TestBatchOperations:
                 raise Exception("Connection failed")
             return NetworkOperationResult(
                 device_name=device_name,
-                ip_address="192.168.1.1",
-                nos="iosxr",
+                ip_address=ipaddress.IPv4Address("192.168.1.1"),
+                nos=NetworkOS.IOSXR,
                 operation_type="test",
                 status=OperationStatus.SUCCESS,
                 data={"device": device_name, "status": "success"},

--- a/tests/cmd/test_validate_command_integration.py
+++ b/tests/cmd/test_validate_command_integration.py
@@ -5,9 +5,9 @@ Tests for validate command integration.
 Tests that the validate command includes topology_adjacency function properly.
 """
 
+import ipaddress
 from src.schemas.models import Device, NetworkOS
 from src.inventory.manager import InventoryManager
-from src.cmd.commands.ops.validate import _run_collector_tests
 
 
 class TestValidateCommandIntegration:
@@ -20,7 +20,7 @@ class TestValidateCommandIntegration:
 
         self.device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57400,
             username="admin",
             password="admin",

--- a/tests/cmd/test_validate_command_simple.py
+++ b/tests/cmd/test_validate_command_simple.py
@@ -5,6 +5,7 @@ Tests for validate command integration.
 Tests that the validate command includes topology_adjacency function properly.
 """
 
+import ipaddress
 from src.schemas.models import Device, NetworkOS
 from src.inventory.manager import InventoryManager
 
@@ -19,7 +20,7 @@ class TestValidateCommandIntegration:
 
         self.device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57400,
             username="admin",
             password="admin",

--- a/tests/collectors/logging/test_logging_functions.py
+++ b/tests/collectors/logging/test_logging_functions.py
@@ -4,6 +4,7 @@ Tests for the logging functions in network_tools/logging.py.
 Uses mocking to test the logging functions without making actual GNMI requests.
 """
 
+import ipaddress
 import os
 import sys
 import pytest
@@ -21,7 +22,7 @@ from src.schemas.responses import (
     ErrorResponse,
     SuccessResponse,
 )
-from src.schemas.models import Device
+from src.schemas.models import Device, NetworkOS
 
 
 class TestLoggingFunctions:
@@ -33,8 +34,8 @@ class TestLoggingFunctions:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -113,8 +114,8 @@ class TestLoggingFunctions:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -145,8 +146,8 @@ class TestLoggingFunctions:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -294,8 +295,8 @@ class TestMinutesValidation:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -326,8 +327,8 @@ class TestMinutesValidation:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )
@@ -356,8 +357,8 @@ class TestMinutesValidation:
         # Create a mock device
         mock_device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
-            nos="iosxr",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
             username="admin",
             password="password",
         )

--- a/tests/collectors/routing/test_simplified_routing.py
+++ b/tests/collectors/routing/test_simplified_routing.py
@@ -3,6 +3,7 @@
 Tests for the simplified routing functionality with metadata-based approach.
 """
 
+import ipaddress
 import os
 import sys
 from unittest.mock import patch
@@ -35,7 +36,7 @@ class TestSimplifiedRoutingFunctionality:
         """Test scenario where BGP is not configured but ISIS is configured."""
         mock_device = Device(
             name="test-device-1",
-            ip_address="10.10.20.103",
+            ip_address=ipaddress.IPv4Address("10.10.20.103"),
             nos=NetworkOS.IOSXR,
             port=57777,
             username="test_user",
@@ -132,7 +133,7 @@ class TestSimplifiedRoutingFunctionality:
         # Create a mock response with mixed results
         mock_response = NetworkOperationResult(
             device_name="test-device",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             nos=NetworkOS.IOSXR,
             operation_type="routing_info",
             status=OperationStatus.PARTIAL_SUCCESS,
@@ -189,7 +190,7 @@ class TestSimplifiedRoutingFunctionality:
         """Test scenario where all protocols are successful."""
         mock_device = Device(
             name="test-device",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             nos=NetworkOS.IOSXR,
             port=57777,
             username="test_user",
@@ -243,7 +244,7 @@ class TestSimplifiedRoutingFunctionality:
         """Test scenario where all protocols are not configured."""
         mock_device = Device(
             name="test-device",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             nos=NetworkOS.IOSXR,
             port=57777,
             username="test_user",
@@ -304,7 +305,7 @@ class TestSimplifiedRoutingFunctionality:
         """Test querying a single protocol that is not configured."""
         mock_device = Device(
             name="test-device",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             nos=NetworkOS.IOSXR,
             port=57777,
             username="test_user",

--- a/tests/collectors/test_summary_types.py
+++ b/tests/collectors/test_summary_types.py
@@ -4,6 +4,7 @@
 Test module to diagnose type annotation issues in NetworkOperationResult response classes
 """
 
+import ipaddress
 import sys
 
 # Add src to path
@@ -12,6 +13,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
 from src.schemas.responses import NetworkOperationResult, OperationStatus
+from src.schemas.models import NetworkOS
 
 
 def test_network_operation_result_structure():
@@ -20,8 +22,8 @@ def test_network_operation_result_structure():
     # Create an instance of NetworkOperationResult to test
     result = NetworkOperationResult(
         device_name="test-device",
-        ip_address="192.168.1.1",
-        nos="iosxr",
+        ip_address=ipaddress.IPv4Address("192.168.1.1"),
+        nos=NetworkOS.IOSXR,
         operation_type="mpls",
         status=OperationStatus.SUCCESS,
         data={"test": "data"},

--- a/tests/gnmi/capabilities/test_checker.py
+++ b/tests/gnmi/capabilities/test_checker.py
@@ -1,3 +1,4 @@
+import ipaddress
 from src.gnmi.capabilities.checker import CapabilityChecker
 from src.gnmi.capabilities.models import DeviceCapabilities, ModelIdentifier
 from src.gnmi.capabilities.service import CapabilityService
@@ -30,7 +31,7 @@ def test_checker_missing_model():
     )
     service = FakeService(caps)
     checker = CapabilityChecker(service, _cmp, EncodingPolicy())
-    device = Device(name="R1", ip_address="1.1.1.1")
+    device = Device(name="R1", ip_address=ipaddress.IPv4Address("1.1.1.1"))
 
     result = checker.check(
         device, ["openconfig-interfaces:interfaces"], GnmiEncoding.JSON_IETF
@@ -51,7 +52,7 @@ def test_checker_older_model_warning_and_success():
     )
     service = FakeService(caps)
     checker = CapabilityChecker(service, _cmp, EncodingPolicy())
-    device = Device(name="R1", ip_address="1.1.1.1")
+    device = Device(name="R1", ip_address=ipaddress.IPv4Address("1.1.1.1"))
 
     result = checker.check(
         device,
@@ -75,7 +76,7 @@ def test_checker_encoding_not_supported():
     )
     service = FakeService(caps)
     checker = CapabilityChecker(service, _cmp, EncodingPolicy())
-    device = Device(name="R1", ip_address="1.1.1.1")
+    device = Device(name="R1", ip_address=ipaddress.IPv4Address("1.1.1.1"))
 
     result = checker.check(
         device, ["openconfig-system:/system"], GnmiEncoding.JSON_IETF
@@ -93,7 +94,7 @@ def test_checker_fallback_encoding():
     )
     service = FakeService(caps)
     checker = CapabilityChecker(service, _cmp, EncodingPolicy())
-    device = Device(name="R1", ip_address="1.1.1.1")
+    device = Device(name="R1", ip_address=ipaddress.IPv4Address("1.1.1.1"))
 
     result = checker.check(device, ["openconfig-system:/system"], "json_ietf")
     assert (

--- a/tests/gnmi/capabilities/test_repository.py
+++ b/tests/gnmi/capabilities/test_repository.py
@@ -1,10 +1,13 @@
+import ipaddress
 from src.gnmi.capabilities.repository import DeviceCapabilitiesRepository
 from src.gnmi.capabilities.models import DeviceCapabilities, ModelIdentifier
 from src.schemas.models import Device
 
 
 def _dev(name="R1"):
-    return Device(name=name, ip_address="10.0.0.1", port=57777)
+    return Device(
+        name=name, ip_address=ipaddress.IPv4Address("10.0.0.1"), port=57777
+    )
 
 
 def test_repo_keying_and_basic_ops():

--- a/tests/gnmi/test_error_handlers.py
+++ b/tests/gnmi/test_error_handlers.py
@@ -3,11 +3,9 @@
 Tests for the error handling functions in gnmi/error_handlers.py.
 """
 
+import ipaddress
 import os
 import sys
-import re
-import pytest
-from unittest.mock import MagicMock, patch
 
 # Add the project root to the Python path
 sys.path.insert(
@@ -15,14 +13,13 @@ sys.path.insert(
 )
 
 import grpc
-from src.schemas.models import Device
+from src.schemas.models import Device, NetworkOS
 from src.gnmi.error_handlers import (
     handle_timeout_error,
     handle_rpc_error,
     handle_connection_refused,
     handle_generic_error,
     _extract_feature_name,
-    _log_error,
 )
 from src.schemas.responses import ErrorResponse, FeatureNotFoundResponse
 
@@ -48,11 +45,11 @@ class Test_ErrorHandlers:
         """Setup test fixtures."""
         self.device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57400,
             username="admin",
             password="admin",
-            nos="iosxr",
+            nos=NetworkOS.IOSXR,
         )
 
     def test_handle_timeout_error(self):
@@ -60,9 +57,10 @@ class Test_ErrorHandlers:
         result = handle_timeout_error(self.device)
         assert isinstance(result, ErrorResponse)
         assert result.type == "CONNECTION_TIMEOUT"
+        assert result.message is not None
         assert "Connection timeout" in result.message
         assert self.device.name in result.message
-        assert self.device.ip_address in result.message
+        assert str(self.device.ip_address) in result.message
         assert "error_class" in result.details
 
     def test_handle_connection_refused(self):
@@ -70,9 +68,10 @@ class Test_ErrorHandlers:
         result = handle_connection_refused(self.device)
         assert isinstance(result, ErrorResponse)
         assert result.type == "CONNECTION_REFUSED"
+        assert result.message is not None
         assert "Connection refused" in result.message
         assert self.device.name in result.message
-        assert self.device.ip_address in result.message
+        assert str(self.device.ip_address) in result.message
 
     def test_handle_rpc_error_regular_error(self):
         """Test the handle_rpc_error function with a regular error."""
@@ -83,6 +82,7 @@ class Test_ErrorHandlers:
         result = handle_rpc_error(self.device, error)
         assert isinstance(result, ErrorResponse)
         assert result.type == "GRPC_ERROR"
+        assert result.message is not None
         assert "gRPC error" in result.message
         assert self.device.name in result.message
         assert error.code().name in result.message
@@ -99,6 +99,7 @@ class Test_ErrorHandlers:
         result = handle_rpc_error(self.device, error)
         assert isinstance(result, FeatureNotFoundResponse)
         assert result.feature_name == feature_name
+        assert result.message is not None
         assert feature_name in result.message
         assert self.device.name in result.message
         assert "code" in result.details
@@ -111,6 +112,7 @@ class Test_ErrorHandlers:
         result = handle_generic_error(self.device, error)
         assert isinstance(result, ErrorResponse)
         assert result.type == "ValueError"
+        assert result.message is not None
         assert str(error) in result.message
 
     def test_handle_generic_error_feature_not_found(self):
@@ -121,6 +123,7 @@ class Test_ErrorHandlers:
         result = handle_generic_error(self.device, error)
         assert isinstance(result, FeatureNotFoundResponse)
         assert result.feature_name == feature_name
+        assert result.message is not None
         assert "not found" in result.message.lower()
         assert self.device.name in result.message
         # The generic error handler creates an empty details dict

--- a/tests/inventory/test_file_handler_paths.py
+++ b/tests/inventory/test_file_handler_paths.py
@@ -208,7 +208,7 @@ class TestFileHandlerPaths:
         assert len(devices) == 2
         assert "test-device-1" in devices
         assert "test-device-2" in devices
-        assert devices["test-device-1"].ip_address == "10.0.0.1"
+        assert str(devices["test-device-1"].ip_address) == "10.0.0.1"
 
     def test_load_inventory_relative_path(self, temp_inventory_file):
         """Test load_inventory with relative path."""
@@ -226,7 +226,7 @@ class TestFileHandlerPaths:
             assert len(devices) == 2
             assert "test-device-1" in devices
             assert "test-device-2" in devices
-            assert devices["test-device-1"].ip_address == "10.0.0.1"
+            assert str(devices["test-device-1"].ip_address) == "10.0.0.1"
         finally:
             os.chdir(original_cwd)
 

--- a/tests/inventory/test_hosts_inventory.py
+++ b/tests/inventory/test_hosts_inventory.py
@@ -31,7 +31,7 @@ class TestHostsInventory:
         assert not isinstance(
             device, DeviceErrorResult
         ), "Should successfully retrieve test-device-1 device"
-        assert device.ip_address == "10.0.0.1"
+        assert str(device.ip_address) == "10.0.0.1"
         assert device.port == 57777
         assert device.nos == NetworkOS.IOSXR
         assert device.username == "test_user"
@@ -81,6 +81,6 @@ class TestHostsInventory:
 
         # Check test-device-2
         test_device_2 = devices["test-device-2"]
-        assert test_device_2.ip_address == "10.0.0.2"
+        assert str(test_device_2.ip_address) == "10.0.0.2"
         assert test_device_2.port == 57777
         assert test_device_2.nos == NetworkOS.IOSXR

--- a/tests/inventory/test_inventory_core.py
+++ b/tests/inventory/test_inventory_core.py
@@ -46,7 +46,7 @@ class TestGetDevice:
         assert not isinstance(device, DeviceErrorResult)
         assert isinstance(device, Device)
         assert device.name == "test-device-1"
-        assert device.ip_address == "10.0.0.1"
+        assert str(device.ip_address) == "10.0.0.1"
 
         # Test getting a non-existent device
         error_result = InventoryManager.get_device("non-existent")
@@ -72,7 +72,7 @@ class TestGetDevice:
         assert not isinstance(device, DeviceErrorResult)
         assert isinstance(device, Device)
         assert device.name == "test-device-1"
-        assert device.ip_address == "10.0.0.1"
+        assert str(device.ip_address) == "10.0.0.1"
         assert device.port == 57777
 
     def test_get_device_from_hosts(self, inventory_paths):
@@ -92,7 +92,7 @@ class TestGetDevice:
         assert not isinstance(device, DeviceErrorResult)
         assert isinstance(device, Device)
         assert device.name == "test-device-2"
-        assert device.ip_address == "10.0.0.2"
+        assert str(device.ip_address) == "10.0.0.2"
         assert device.port == 57777
         assert device.username == "test_user"
 

--- a/tests/inventory/test_manager.py
+++ b/tests/inventory/test_manager.py
@@ -4,6 +4,7 @@ Tests for the inventory manager module.
 Focuses on testing the get_device and list_devices functions.
 """
 
+import ipaddress
 import os
 import unittest
 from unittest.mock import patch
@@ -139,7 +140,7 @@ class TestAutoInitialization(unittest.TestCase):
         # Setup the mocked devices
         test_device1 = Device(
             name="test-device-1",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="test_user",
@@ -147,7 +148,7 @@ class TestAutoInitialization(unittest.TestCase):
         )
         test_device2 = Device(
             name="test-device-2",
-            ip_address="10.0.0.2",
+            ip_address=ipaddress.IPv4Address("10.0.0.2"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="test_user",
@@ -186,7 +187,7 @@ class TestAutoInitialization(unittest.TestCase):
         # Setup the mocked device
         test_device = Device(
             name="test-device-1",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="test_user",
@@ -220,7 +221,7 @@ class TestAutoInitialization(unittest.TestCase):
         # Setup the mocked device
         test_device = Device(
             name="test-device-1",
-            ip_address="10.0.0.1",
+            ip_address=ipaddress.IPv4Address("10.0.0.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="test_user",

--- a/tests/inventory/test_manager.py
+++ b/tests/inventory/test_manager.py
@@ -43,7 +43,7 @@ class TestInventoryManager(unittest.TestCase):
         self.assertFalse(isinstance(device, DeviceErrorResult))
         self.assertIsInstance(device, Device)
         self.assertEqual(device.name, "test-device-1")
-        self.assertEqual(device.ip_address, "10.0.0.1")
+        self.assertEqual(str(device.ip_address), "10.0.0.1")
         self.assertEqual(device.port, 57777)
         self.assertEqual(device.nos, NetworkOS.IOSXR)
         self.assertEqual(device.username, "test_user")
@@ -88,7 +88,7 @@ class TestInventoryManager(unittest.TestCase):
 
         # Verify device properties
         device1 = devices["test-device-1"]
-        self.assertEqual(device1.ip_address, "10.0.0.1")
+        self.assertEqual(str(device1.ip_address), "10.0.0.1")
         self.assertEqual(device1.port, 57777)
         self.assertEqual(device1.nos, NetworkOS.IOSXR)
 
@@ -120,7 +120,7 @@ class TestInventoryManager(unittest.TestCase):
         # Check if we can get the first test device
         device = InventoryManager.get_device("test-device-1")
         self.assertFalse(isinstance(device, DeviceErrorResult))
-        self.assertEqual(device.ip_address, "10.0.0.1")
+        self.assertEqual(str(device.ip_address), "10.0.0.1")
 
 
 @patch("src.inventory.manager.InventoryManager.initialize")

--- a/tests/inventory/test_sanitizer.py
+++ b/tests/inventory/test_sanitizer.py
@@ -6,6 +6,7 @@ Tests sensitive data redaction, non-sensitive data preservation,
 class-based data structures, and edge cases.
 """
 
+import ipaddress
 import pytest
 from typing import List
 from src.inventory.sanitizer import DeviceDataSanitizer
@@ -25,7 +26,7 @@ class TestDeviceDataSanitizer:
         """Create a test device with sensitive authentication data."""
         return Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -46,7 +47,7 @@ class TestDeviceDataSanitizer:
         """Create a test device without sensitive authentication data."""
         return Device(
             name="test-device-minimal",
-            ip_address="10.1.1.1",
+            ip_address=ipaddress.IPv4Address("10.1.1.1"),
             port=830,
             nos=NetworkOS.IOSXR,
             username="user",
@@ -78,7 +79,7 @@ class TestDeviceDataSanitizer:
 
         # Verify non-sensitive data is preserved
         assert sanitized.name == "test-device"
-        assert sanitized.ip_address == "192.168.1.1"
+        assert sanitized.ip_address == ipaddress.IPv4Address("192.168.1.1")
         assert sanitized.port == 57777
         assert sanitized.nos == NetworkOS.IOSXR
         assert sanitized.username == "admin"
@@ -115,7 +116,7 @@ class TestDeviceDataSanitizer:
 
         # Verify all other data is preserved
         assert sanitized.name == "test-device-minimal"
-        assert sanitized.ip_address == "10.1.1.1"
+        assert sanitized.ip_address == ipaddress.IPv4Address("10.1.1.1")
         assert sanitized.port == 830
         assert sanitized.nos == NetworkOS.IOSXR
         assert sanitized.username == "user"
@@ -209,7 +210,7 @@ class TestDeviceDataSanitizer:
         """Test handling of empty string password."""
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="",  # Empty string
             path_cert="",  # Empty string
@@ -227,7 +228,7 @@ class TestDeviceDataSanitizer:
         """Test handling of whitespace-only sensitive fields."""
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="   ",  # Whitespace only
             path_cert="\t\n",  # Tabs and newlines
@@ -249,7 +250,7 @@ class TestDeviceDataSanitizer:
 
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="secret123",
         )

--- a/tests/schemas/test_models.py
+++ b/tests/schemas/test_models.py
@@ -77,7 +77,7 @@ class TestDeviceModel:
 
         # Test all default values
         assert device.name == ""
-        assert device.ip_address == ""
+        assert str(device.ip_address) == "127.0.0.1"
         assert device.port == 830
         assert device.nos == NetworkOS.IOSXR
         assert device.username is None  # Now optional
@@ -139,11 +139,17 @@ class TestDeviceModel:
 
     def test_device_field_types(self):
         """Test that Device fields have correct type annotations."""
+        import ipaddress
+        from typing import Union
+
         type_hints = get_type_hints(Device)
 
         # Test key field types
         assert type_hints["name"] == str
-        assert type_hints["ip_address"] == str
+        assert (
+            type_hints["ip_address"]
+            == Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+        )
         assert type_hints["port"] == int
         assert type_hints["nos"] == NetworkOS
         assert type_hints["username"] == Optional[str]  # Now optional
@@ -269,7 +275,7 @@ class TestDeviceModelIntegration:
         device = Device(**converted_data)
 
         assert device.name == "PE1-NYC"
-        assert device.ip_address == "10.0.1.100"
+        assert str(device.ip_address) == "10.0.1.100"
         assert device.port == 57400
         assert device.nos == NetworkOS.IOSXR
         assert device.username == "gnmi"

--- a/tests/schemas/test_models.py
+++ b/tests/schemas/test_models.py
@@ -2,10 +2,11 @@
 """
 Tests for device models in src/schemas/models.py.
 
-Tests the Device dataclass and related TypedDict classes to ensure
+Tests the Device dataclass and related dataclass models to ensure
 proper validation and functionality.
 """
 
+import ipaddress
 from dataclasses import fields
 from typing import get_type_hints, Optional
 from src.schemas.models import (
@@ -22,11 +23,13 @@ class TestDeviceModel:
     def test_device_creation_with_minimal_fields(self):
         """Test Device creation with only required fields."""
         device = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
         assert device.name == "test-device"
-        assert device.ip_address == "192.168.1.1"
+        assert device.ip_address == ipaddress.IPv4Address("192.168.1.1")
         assert device.nos == NetworkOS.IOSXR
         assert device.port == 830  # Default value
         assert device.username is None  # Default value (optional)
@@ -39,7 +42,7 @@ class TestDeviceModel:
         """Test Device creation with all fields specified."""
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57400,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -56,7 +59,7 @@ class TestDeviceModel:
         )
 
         assert device.name == "test-device"
-        assert device.ip_address == "192.168.1.1"
+        assert device.ip_address == ipaddress.IPv4Address("192.168.1.1")
         assert device.port == 57400
         assert device.nos == NetworkOS.IOSXR
         assert device.username == "admin"
@@ -96,7 +99,7 @@ class TestDeviceModel:
         """Test that to_device_info method has been removed."""
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             port=57400,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -108,7 +111,7 @@ class TestDeviceModel:
 
         # Verify the device still works for basic functionality
         assert device.name == "test-device"
-        assert device.ip_address == "192.168.1.1"
+        assert device.ip_address == ipaddress.IPv4Address("192.168.1.1")
         assert device.port == 57400
         assert device.nos == NetworkOS.IOSXR
 
@@ -161,16 +164,20 @@ class TestDeviceModel:
     def test_device_equality(self):
         """Test Device equality comparison."""
         device1 = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
         device2 = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
         device3 = Device(
             name="different-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
         )
 
@@ -180,7 +187,9 @@ class TestDeviceModel:
     def test_device_string_representation(self):
         """Test Device string representation."""
         device = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
         device_str = str(device)
@@ -190,31 +199,43 @@ class TestDeviceModel:
 
 
 class TestDeviceListResult:
-    """Test suite for DeviceListResult TypedDict."""
+    """Test suite for DeviceListResult dataclass."""
 
     def test_device_list_result_structure(self):
         """Test that DeviceListResult has correct structure."""
-        # This is a TypedDict, so we test with actual data
-        device_list: DeviceListResult = {
-            "devices": [
-                {"name": "device1", "ip_address": "192.168.1.1"},
-                {"name": "device2", "ip_address": "192.168.1.2"},
-            ]
-        }
+        # Create some test devices
+        device1 = Device(
+            name="device1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
+        )
+        device2 = Device(
+            name="device2",
+            ip_address=ipaddress.IPv4Address("192.168.1.2"),
+            nos=NetworkOS.IOSXR,
+        )
 
-        assert "devices" in device_list
-        assert isinstance(device_list["devices"], list)
-        assert len(device_list["devices"]) == 2
-        assert device_list["devices"][0]["name"] == "device1"
-        assert device_list["devices"][1]["name"] == "device2"
+        device_list = DeviceListResult(devices=[device1, device2])
+
+        assert hasattr(device_list, "devices")
+        assert isinstance(device_list.devices, list)
+        assert len(device_list.devices) == 2
+        assert device_list.devices[0].name == "device1"
+        assert device_list.devices[1].name == "device2"
+        assert device_list.devices[0].ip_address == ipaddress.IPv4Address(
+            "192.168.1.1"
+        )
+        assert device_list.devices[1].ip_address == ipaddress.IPv4Address(
+            "192.168.1.2"
+        )
 
     def test_device_list_result_empty(self):
         """Test DeviceListResult with empty device list."""
-        device_list: DeviceListResult = {"devices": []}
+        device_list = DeviceListResult(devices=[])
 
-        assert "devices" in device_list
-        assert isinstance(device_list["devices"], list)
-        assert len(device_list["devices"]) == 0
+        assert hasattr(device_list, "devices")
+        assert isinstance(device_list.devices, list)
+        assert len(device_list.devices) == 0
 
 
 class TestDeviceErrorResult:
@@ -225,7 +246,7 @@ class TestDeviceErrorResult:
         error_result = DeviceErrorResult(
             msg="Connection failed",
             nos=NetworkOS.IOSXR,
-            ip_address=None,
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             device_info={
                 "name": "test-device",
                 "ip_address": "192.168.1.1",
@@ -292,7 +313,7 @@ class TestDeviceSanitizationMethods:
         """Test that Device model maintains a clean interface without deprecated methods."""
         device = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             username="admin",
             password="secret123",
@@ -307,7 +328,7 @@ class TestDeviceSanitizationMethods:
 
         # Verify the device still works as expected for actual use cases
         assert device.name == "test-device"
-        assert device.ip_address == "192.168.1.1"
+        assert device.ip_address == ipaddress.IPv4Address("192.168.1.1")
         assert (
             device.password == "secret123"
         )  # Full data preserved in Device object

--- a/tests/schemas/test_models.py
+++ b/tests/schemas/test_models.py
@@ -148,7 +148,7 @@ class TestDeviceModel:
         assert type_hints["name"] == str
         assert (
             type_hints["ip_address"]
-            == Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+            == Union[ipaddress.IPv4Address, ipaddress.IPv6Address, None]
         )
         assert type_hints["port"] == int
         assert type_hints["nos"] == NetworkOS

--- a/tests/schemas/test_models.py
+++ b/tests/schemas/test_models.py
@@ -218,37 +218,37 @@ class TestDeviceListResult:
 
 
 class TestDeviceErrorResult:
-    """Test suite for DeviceErrorResult TypedDict."""
+    """Test suite for DeviceErrorResult dataclass."""
 
     def test_device_error_result_with_device_info(self):
         """Test DeviceErrorResult with device information."""
-        error_result: DeviceErrorResult = {
-            "error": "Connection failed",
-            "device_info": {
+        error_result = DeviceErrorResult(
+            msg="Connection failed",
+            nos=NetworkOS.IOSXR,
+            ip_address=None,
+            device_info={
                 "name": "test-device",
                 "ip_address": "192.168.1.1",
                 "port": 57400,
                 "nos": "iosxr",
             },
-        }
+        )
 
-        assert "error" in error_result
-        assert "device_info" in error_result
-        assert error_result["error"] == "Connection failed"
-        assert error_result["device_info"] is not None
-        assert error_result["device_info"]["name"] == "test-device"
+        assert error_result.msg == "Connection failed"
+        assert error_result.nos == NetworkOS.IOSXR
+        assert error_result.device_info is not None
+        assert error_result.device_info["name"] == "test-device"
 
     def test_device_error_result_without_device_info(self):
         """Test DeviceErrorResult without device information."""
-        error_result: DeviceErrorResult = {
-            "error": "Generic error",
-            "device_info": None,
-        }
+        error_result = DeviceErrorResult(
+            msg="Generic error",
+            device_info=None,
+        )
 
-        assert "error" in error_result
-        assert "device_info" in error_result
-        assert error_result["error"] == "Generic error"
-        assert error_result["device_info"] is None
+        assert error_result.msg == "Generic error"
+        assert error_result.nos == NetworkOS.UNKNOWN  # Default value
+        assert error_result.device_info is None
 
 
 class TestDeviceModelIntegration:

--- a/tests/schemas/test_models.py
+++ b/tests/schemas/test_models.py
@@ -77,7 +77,7 @@ class TestDeviceModel:
 
         # Test all default values
         assert device.name == ""
-        assert str(device.ip_address) == "127.0.0.1"
+        assert device.ip_address == None
         assert device.port == 830
         assert device.nos == NetworkOS.IOSXR
         assert device.username is None  # Now optional

--- a/tests/schemas/test_responses.py
+++ b/tests/schemas/test_responses.py
@@ -7,6 +7,7 @@ and functionality for the new NetworkOperationResult architecture.
 """
 
 import json
+from ipaddress import ip_address
 from dataclasses import fields
 from typing import get_type_hints
 from src.schemas.responses import (
@@ -16,7 +17,7 @@ from src.schemas.responses import (
     SuccessResponse,
     NetworkOperationResult,
 )
-from src.schemas.models import Device
+from src.schemas.models import Device, IPAddress
 from src.schemas.responses import NetworkOS
 
 
@@ -180,21 +181,23 @@ class TestNetworkOperationResult:
     def setup_method(self):
         """Setup test fixtures."""
         self.device = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ip_address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
     def test_network_operation_result_creation_minimal(self):
         """Test NetworkOperationResult creation with minimal required fields."""
         result = NetworkOperationResult(
             device_name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ip_address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             operation_type="system_info",
             status=OperationStatus.SUCCESS,
         )
 
         assert result.device_name == "test-device"
-        assert result.ip_address == "192.168.1.1"
+        assert result.ip_address == ip_address("192.168.1.1")
         assert result.nos == NetworkOS.IOSXR
         assert result.operation_type == "system_info"
         assert result.status == OperationStatus.SUCCESS
@@ -270,7 +273,7 @@ class TestNetworkOperationResult:
         """Test NetworkOperationResult default values."""
         result = NetworkOperationResult(
             device_name="test",
-            ip_address="1.1.1.1",
+            ip_address=ip_address("1.1.1.1"),
             nos=NetworkOS.IOSXR,
             operation_type="test",
             status=OperationStatus.SUCCESS,
@@ -286,7 +289,7 @@ class TestNetworkOperationResult:
         type_hints = get_type_hints(NetworkOperationResult)
 
         assert type_hints["device_name"] == str
-        assert type_hints["ip_address"] == str
+        assert type_hints["ip_address"] == IPAddress
         assert type_hints["nos"] == NetworkOS
         assert type_hints["operation_type"] == str
         assert type_hints["status"] == OperationStatus
@@ -317,7 +320,9 @@ class TestResponseSerializationIntegration:
     def setup_method(self):
         """Setup test fixtures."""
         self.device = Device(
-            name="test-device", ip_address="192.168.1.1", nos=NetworkOS.IOSXR
+            name="test-device",
+            ip_address=ip_address("192.168.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
     def test_successful_operation_serialization(self):
@@ -345,7 +350,7 @@ class TestResponseSerializationIntegration:
         # Should be JSON serializable
         result_dict = {
             "device_name": result.device_name,
-            "ip_address": result.ip_address,
+            "ip_address": str(result.ip_address),
             "nos": str(result.nos),
             "operation_type": result.operation_type,
             "status": result.status.value,

--- a/tests/test_api_mcp_integration.py
+++ b/tests/test_api_mcp_integration.py
@@ -6,12 +6,12 @@ Tests api.get_devices() returns sanitized data, MCP server tool registration,
 class-based data structures, and automatic sanitization inheritance.
 """
 
+import ipaddress
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import api
 from src.schemas.models import Device, DeviceListResult, NetworkOS
-from src.inventory.manager import InventoryManager
 
 
 class TestAPIIntegration:
@@ -22,7 +22,7 @@ class TestAPIIntegration:
         """Create a mock device with sensitive authentication data."""
         return Device(
             name="api-test-device",
-            ip_address="10.0.1.100",
+            ip_address=ipaddress.IPv4Address("10.0.1.100"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="gnmi_user",
@@ -45,7 +45,7 @@ class TestAPIIntegration:
         """Create a mock sanitized device list result."""
         sanitized_device = Device(
             name="api-test-device",
-            ip_address="10.0.1.100",
+            ip_address=ipaddress.IPv4Address("10.0.1.100"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="gnmi_user",
@@ -91,7 +91,7 @@ class TestAPIIntegration:
 
             # Verify non-sensitive data is preserved
             assert device.name == "api-test-device"
-            assert device.ip_address == "10.0.1.100"
+            assert device.ip_address == ipaddress.IPv4Address("10.0.1.100")
             assert device.username == "gnmi_user"
             assert device.path_root == "/secure/ca.pem"  # Not sensitive
 
@@ -160,7 +160,7 @@ class TestAPIIntegration:
         # Create multiple devices with different sensitivity patterns
         device1 = Device(
             name="device-1",
-            ip_address="10.0.1.1",
+            ip_address=ipaddress.IPv4Address("10.0.1.1"),
             nos=NetworkOS.IOSXR,
             password="***",
             path_cert="***",
@@ -168,7 +168,7 @@ class TestAPIIntegration:
 
         device2 = Device(
             name="device-2",
-            ip_address="10.0.1.2",
+            ip_address=ipaddress.IPv4Address("10.0.1.2"),
             nos=NetworkOS.IOSXR,
             password=None,  # No password
             path_cert=None,  # No cert
@@ -240,7 +240,7 @@ class TestMCPServerIntegration:
         # Mock a sanitized device result
         sanitized_device = Device(
             name="mcp-test-device",
-            ip_address="172.16.1.1",
+            ip_address=ipaddress.IPv4Address("172.16.1.1"),
             nos=NetworkOS.IOSXR,
             username="mcp_user",
             password="***",  # Sanitized
@@ -301,7 +301,7 @@ class TestMCPServerIntegration:
 
         sanitized_device = Device(
             name="flow-test-device",
-            ip_address="192.168.100.1",
+            ip_address=ipaddress.IPv4Address("192.168.100.1"),
             nos=NetworkOS.IOSXR,
             password="***",
             path_cert="***",
@@ -328,7 +328,7 @@ class TestMCPServerIntegration:
 
         sanitized_device = Device(
             name="class-test-device",
-            ip_address="10.100.1.1",
+            ip_address=ipaddress.IPv4Address("10.100.1.1"),
             nos=NetworkOS.IOSXR,
             username="test_user",
             password="***",
@@ -360,7 +360,7 @@ class TestMCPServerIntegration:
         # Create a result that matches the expected interface
         test_device = Device(
             name="compat-test",
-            ip_address="172.20.1.1",
+            ip_address=ipaddress.IPv4Address("172.20.1.1"),
             nos=NetworkOS.IOSXR,
             password="***",
         )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -6,6 +6,7 @@ Verifies all existing functionality still works, performance hasn't degraded,
 error handling remains intact, and backward compatibility is maintained.
 """
 
+import ipaddress
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -24,7 +25,7 @@ class TestRegressionFunctionality:
         """Create a sample device for testing."""
         return Device(
             name="regression-test-device",
-            ip_address="192.168.100.1",
+            ip_address=ipaddress.IPv4Address("192.168.100.1"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="test_user",
@@ -74,7 +75,7 @@ class TestRegressionFunctionality:
 
             # Verify non-sensitive data is preserved
             assert device.name == "regression-test-device"
-            assert device.ip_address == "192.168.100.1"
+            assert device.ip_address == ipaddress.IPv4Address("192.168.100.1")
 
     def test_device_model_cleanup_verification(self, sample_device):
         """Test that deprecated device methods have been properly removed."""
@@ -85,7 +86,9 @@ class TestRegressionFunctionality:
 
         # Verify the device still works for core functionality
         assert sample_device.name == "regression-test-device"
-        assert sample_device.ip_address == "192.168.100.1"
+        assert sample_device.ip_address == ipaddress.IPv4Address(
+            "192.168.100.1"
+        )
         assert (
             sample_device.password == "test_password"
         )  # Sensitive data intact in Device object
@@ -95,7 +98,9 @@ class TestRegressionFunctionality:
 
         # Test device creation with minimal fields (original way)
         device = Device(
-            name="compat-test", ip_address="10.1.1.1", nos=NetworkOS.IOSXR
+            name="compat-test",
+            ip_address=ipaddress.IPv4Address("10.1.1.1"),
+            nos=NetworkOS.IOSXR,
         )
 
         # Verify default values are unchanged
@@ -109,7 +114,7 @@ class TestRegressionFunctionality:
         # Test device creation with all fields (original way)
         full_device = Device(
             name="full-test",
-            ip_address="10.1.1.2",
+            ip_address=ipaddress.IPv4Address("10.1.1.2"),
             port=57777,
             nos=NetworkOS.IOSXR,
             username="admin",
@@ -172,21 +177,21 @@ class TestRegressionFunctionality:
 
         device1 = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="secret",
         )
 
         device2 = Device(
             name="test-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="secret",
         )
 
         device3 = Device(
             name="different-device",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="secret",
         )
@@ -211,7 +216,7 @@ class TestRegressionPerformance:
         for i in range(100):
             device = Device(
                 name=f"perf-test-device-{i}",
-                ip_address=f"192.168.1.{i+1}",
+                ip_address=ipaddress.IPv4Address(f"192.168.1.{i+1}"),
                 nos=NetworkOS.IOSXR,
                 username="admin",
                 password=f"password_{i}",
@@ -247,7 +252,7 @@ class TestRegressionPerformance:
         devices = [
             Device(
                 name=f"list-perf-{i}",
-                ip_address=f"10.0.0.{i+1}",
+                ip_address=ipaddress.IPv4Address(f"10.0.0.{i+1}"),
                 nos=NetworkOS.IOSXR,
                 password=f"secret_{i}",
             )
@@ -293,7 +298,7 @@ class TestRegressionPerformance:
         devices = [
             Device(
                 name=f"api-perf-{i}",
-                ip_address=f"172.16.0.{i+1}",
+                ip_address=ipaddress.IPv4Address(f"172.16.0.{i+1}"),
                 nos=NetworkOS.IOSXR,
                 password="secret",
             )
@@ -303,7 +308,7 @@ class TestRegressionPerformance:
         sanitized_devices = [
             Device(
                 name=f"api-perf-{i}",
-                ip_address=f"172.16.0.{i+1}",
+                ip_address=ipaddress.IPv4Address(f"172.16.0.{i+1}"),
                 nos=NetworkOS.IOSXR,
                 password="***",
             )
@@ -338,7 +343,7 @@ class TestRegressionEdgeCases:
 
         device = Device(
             name="none-test",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             username=None,
             password=None,
@@ -361,7 +366,7 @@ class TestRegressionEdgeCases:
 
         device = Device(
             name="special-char-test",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="p@$$w0rd!@#$%^&*()",
             path_cert="/path/with spaces/cert-file.pem",
@@ -394,7 +399,7 @@ class TestRegressionDataIntegrity:
 
         device = Device(
             name="immutability-test",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password=original_password,
             path_cert=original_cert,
@@ -420,7 +425,7 @@ class TestRegressionDataIntegrity:
         """Test that Device objects maintain basic functionality after cleanup."""
         device = Device(
             name="basic-test",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="test_password",
         )
@@ -428,12 +433,12 @@ class TestRegressionDataIntegrity:
         # Verify basic Device functionality still works
         assert device.name == "basic-test"
         assert device.password == "test_password"
-        assert device.ip_address == "192.168.1.1"
+        assert device.ip_address == ipaddress.IPv4Address("192.168.1.1")
 
         # Verify equality comparison still works
         device2 = Device(
             name="basic-test",
-            ip_address="192.168.1.1",
+            ip_address=ipaddress.IPv4Address("192.168.1.1"),
             nos=NetworkOS.IOSXR,
             password="test_password",
         )


### PR DESCRIPTION
# Add Proper IP Address Typing with ipaddress Module

## Overview

This PR replaces string-based IP address handling with proper IP address typing using Python's built-in `ipaddress` module. This change improves type safety, validation, and provides better structure for IP address handling throughout the application.

## Changes Made

### Core Model Changes

- **Device Model**: Changed `ip_address` field from `str` to `IPAddress` (Union of IPv4Address, IPv6Address, or None)
- **NetworkOperationResult**: Updated `ip_address` field to use proper IP address typing
- **DeviceErrorResult**: Updated `ip_address` field with proper typing and default values
- Added `host` property to Device class for string representation needed by network connections

### Test Updates

- Updated all test files to use `ipaddress.IPv4Address()` and `ipaddress.IPv6Address()` objects
- Enhanced test coverage for IP address validation and conversion
- Updated mock objects and fixtures to use proper IP address types

## Closes

Closes #35